### PR TITLE
Localize backend responses to Spanish

### DIFF
--- a/Backend/src/application/use-cases/google-auth.usecase.ts
+++ b/Backend/src/application/use-cases/google-auth.usecase.ts
@@ -15,7 +15,7 @@ export class GoogleAuthUseCase {
     const ticket = await this.googleClient.verifyIdToken({ idToken });
     const payload = ticket.getPayload();
     if (!payload?.sub || !payload.email || !payload.name) {
-      throw new Error('Invalid Google token');
+      throw new Error('Token de Google inválido');
     }
     const externalId = payload.sub;
     const email = payload.email;

--- a/Backend/src/application/use-cases/link-google.usecase.ts
+++ b/Backend/src/application/use-cases/link-google.usecase.ts
@@ -12,12 +12,12 @@ export class LinkGoogleUseCase {
     const ticket = await this.googleClient.verifyIdToken({ idToken });
     const payload = ticket.getPayload();
     if (!payload?.sub) {
-      throw new Error('Invalid Google token');
+      throw new Error('Token de Google inválido');
     }
     const externalId = payload.sub;
     const user = await this.userRepository.findById(userId);
     if (!user) {
-      throw new Error('User not found');
+      throw new Error('Usuario no encontrado');
     }
     if (user.oauthProviders.some((p) => p.provider === 'google')) {
       return user;

--- a/Backend/src/application/use-cases/login-user.usecase.ts
+++ b/Backend/src/application/use-cases/login-user.usecase.ts
@@ -11,11 +11,11 @@ export class LoginUserUseCase {
   async execute(email: string, password: string) {
     const user = await this.userRepository.findByEmail(email);
     if (!user || !user.passwordHash) {
-      throw new Error('Invalid credentials');
+      throw new Error('Credenciales inválidas');
     }
     const valid = await bcrypt.compare(password, user.passwordHash);
     if (!valid) {
-      throw new Error('Invalid credentials');
+      throw new Error('Credenciales inválidas');
     }
     const token = this.jwtService.sign(user);
     return { user, token };

--- a/Backend/src/application/use-cases/register-user.usecase.ts
+++ b/Backend/src/application/use-cases/register-user.usecase.ts
@@ -13,7 +13,7 @@ export class RegisterUserUseCase {
   ): Promise<User> {
     const existing = await this.userRepository.findByEmail(email);
     if (existing) {
-      throw new Error('Email already in use');
+      throw new Error('Correo electrónico ya en uso');
     }
     const passwordHash = await bcrypt.hash(password, 10);
     const user = await this.userRepository.create({

--- a/Backend/src/interfaces/http/controllers/auth.controller.ts
+++ b/Backend/src/interfaces/http/controllers/auth.controller.ts
@@ -42,9 +42,9 @@ export class AuthController {
     res.json({ user, token });
   };
 
-  linkGoogleAccount = async (req: AuthRequest, res: Response) => {
+  linkGoogleAccount = async (req: Request, res: Response) => {
     const { idToken } = req.body as GoogleRequestDto;
-    const user = await this.linkGoogle.execute(req.userId, idToken);
+    const user = await this.linkGoogle.execute((req as AuthRequest).userId, idToken);
     res.json({ user });
   };
 }

--- a/Backend/src/interfaces/middleware/auth.middleware.ts
+++ b/Backend/src/interfaces/middleware/auth.middleware.ts
@@ -6,17 +6,17 @@ export const authMiddleware =
   (req: Request, res: Response, next: NextFunction): void => {
     const authHeader = req.headers.authorization;
     if (!authHeader) {
-      res.status(401).json({ error: 'Unauthorized' });
+      res.status(401).json({ error: 'No autorizado' });
       return;
     }
     const parts = authHeader.split(' ');
     if (parts.length !== 2) {
-      res.status(401).json({ error: 'Unauthorized' });
+      res.status(401).json({ error: 'No autorizado' });
       return;
     }
     const token = parts[1];
     if (!token) {
-      res.status(401).json({ error: 'Unauthorized' });
+      res.status(401).json({ error: 'No autorizado' });
       return;
     }
     try {
@@ -24,6 +24,6 @@ export const authMiddleware =
       (req as Request & { userId: string }).userId = payload.userId;
       next();
     } catch {
-      res.status(401).json({ error: 'Unauthorized' });
+      res.status(401).json({ error: 'No autorizado' });
     }
   };

--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -7,15 +7,15 @@ const app = express();
 app.use(express.json());
 
 connectMongo()
-  .then(() => console.log('Connected to MongoDB'))
-  .catch((err) => console.error('MongoDB connection error', err));
+  .then(() => console.log('Conectado a MongoDB'))
+  .catch((err) => console.error('Error de conexión con MongoDB', err));
 
 app.use('/api/v1/auth', authRoutes);
 
 app.get('/', (_req, res) => {
-  res.send('Nidify API');
+  res.send('API de Nidify');
 });
 
 app.listen(config.port, () => {
-  console.log(`Server running on port ${config.port}`);
+  console.log(`Servidor ejecutándose en el puerto ${config.port}`);
 });


### PR DESCRIPTION
## Summary
- translate authentication middleware error messages to Spanish
- localize server logs and user-facing error strings across use cases
- fix link Google controller signature for proper TypeScript build

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fe35338b08326945a3ec960ff3786