### PR TITLE
Add household creation and invitations

### DIFF
--- a/Backend/src/application/use-cases/accept-invitation.usecase.ts
+++ b/Backend/src/application/use-cases/accept-invitation.usecase.ts
@@ -1,0 +1,52 @@
+import { InvitationRepository } from '../../infrastructure/persistence/repositories/invitation.repository';
+import { HouseholdMembershipRepository } from '../../infrastructure/persistence/repositories/household-membership.repository';
+import { InvitationStatus } from '../../domain/models/enums/invitation-status.enum';
+import { MembershipStatus } from '../../domain/models/enums/membership-status.enum';
+import { MembershipRole } from '../../domain/models/enums/membership-role.enum';
+import { HouseholdMembership } from '../../domain/models/household-membership.model';
+
+export class AcceptInvitationUseCase {
+  constructor(
+    private invitationRepo: InvitationRepository,
+    private membershipRepo: HouseholdMembershipRepository,
+  ) {}
+
+  async execute(token: string, userId: string): Promise<HouseholdMembership> {
+    const invitation = await this.invitationRepo.findByToken(token);
+    if (!invitation || invitation.status !== InvitationStatus.PENDING) {
+      throw new Error('Invitación inválida');
+    }
+
+    await this.invitationRepo.update(invitation.id, {
+      status: InvitationStatus.ACCEPTED,
+      usageAttempts: invitation.usageAttempts + 1,
+    });
+
+    const existing = await this.membershipRepo.findByUserAndHousehold(
+      userId,
+      invitation.householdId,
+    );
+    if (existing) {
+      const updated = await this.membershipRepo.updateStatus(
+        existing.id,
+        MembershipStatus.ACTIVE,
+      );
+      if (!updated) {
+        throw new Error('No se pudo actualizar la membresía');
+      }
+      return updated;
+    }
+
+    const now = new Date();
+    const membership = await this.membershipRepo.create({
+      userId,
+      householdId: invitation.householdId,
+      role: MembershipRole.MEMBER,
+      status: MembershipStatus.ACTIVE,
+      joinedAt: now,
+      invitedBy: invitation.invitedBy,
+    });
+
+    return membership;
+  }
+}

--- a/Backend/src/application/use-cases/create-household.usecase.ts
+++ b/Backend/src/application/use-cases/create-household.usecase.ts
@@ -1,0 +1,37 @@
+import { Household } from '../../domain/models/household.model';
+import { HouseholdRepository } from '../../infrastructure/persistence/repositories/household.repository';
+import { HouseholdMembershipRepository } from '../../infrastructure/persistence/repositories/household-membership.repository';
+import { MembershipRole } from '../../domain/models/enums/membership-role.enum';
+import { MembershipStatus } from '../../domain/models/enums/membership-status.enum';
+
+export class CreateHouseholdUseCase {
+  constructor(
+    private householdRepo: HouseholdRepository,
+    private membershipRepo: HouseholdMembershipRepository,
+  ) {}
+
+  async execute(
+    userId: string,
+    name: string,
+    baseCurrency: string,
+  ): Promise<Household> {
+    const now = new Date();
+    const household = await this.householdRepo.create({
+      name,
+      baseCurrency,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await this.membershipRepo.create({
+      userId,
+      householdId: household.id,
+      role: MembershipRole.ADMIN,
+      status: MembershipStatus.ACTIVE,
+      joinedAt: now,
+      invitedBy: userId,
+    });
+
+    return household;
+  }
+}

--- a/Backend/src/application/use-cases/invite-to-household.usecase.ts
+++ b/Backend/src/application/use-cases/invite-to-household.usecase.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from 'crypto';
+import { InvitationRepository } from '../../infrastructure/persistence/repositories/invitation.repository';
+import { HouseholdMembershipRepository } from '../../infrastructure/persistence/repositories/household-membership.repository';
+import { UserRepository } from '../../infrastructure/persistence/repositories/user.repository';
+import { MembershipRole } from '../../domain/models/enums/membership-role.enum';
+import { MembershipStatus } from '../../domain/models/enums/membership-status.enum';
+import { InvitationStatus } from '../../domain/models/enums/invitation-status.enum';
+import { Invitation } from '../../domain/models/invitation.model';
+
+export class InviteToHouseholdUseCase {
+  constructor(
+    private membershipRepo: HouseholdMembershipRepository,
+    private invitationRepo: InvitationRepository,
+    private userRepo: UserRepository,
+  ) {}
+
+  async execute(
+    inviterId: string,
+    householdId: string,
+    email: string,
+  ): Promise<Invitation> {
+    const inviter = await this.membershipRepo.findByUserAndHousehold(
+      inviterId,
+      householdId,
+    );
+    if (
+      !inviter ||
+      inviter.role !== MembershipRole.ADMIN ||
+      inviter.status !== MembershipStatus.ACTIVE
+    ) {
+      throw new Error('No autorizado');
+    }
+
+    const token = randomUUID();
+    const now = new Date();
+    const invitation = await this.invitationRepo.create({
+      householdId,
+      email,
+      token,
+      createdAt: now,
+      status: InvitationStatus.PENDING,
+      invitedBy: inviterId,
+      usageAttempts: 0,
+    });
+
+    const existingUser = await this.userRepo.findByEmail(email);
+    if (existingUser) {
+      await this.membershipRepo.create({
+        userId: existingUser.id,
+        householdId,
+        role: MembershipRole.MEMBER,
+        status: MembershipStatus.PENDING,
+        joinedAt: now,
+        invitedBy: inviterId,
+      });
+    }
+
+    return invitation;
+  }
+}

--- a/Backend/src/application/use-cases/revoke-membership.usecase.ts
+++ b/Backend/src/application/use-cases/revoke-membership.usecase.ts
@@ -1,0 +1,32 @@
+import { HouseholdMembershipRepository } from '../../infrastructure/persistence/repositories/household-membership.repository';
+import { MembershipRole } from '../../domain/models/enums/membership-role.enum';
+import { MembershipStatus } from '../../domain/models/enums/membership-status.enum';
+
+export class RevokeMembershipUseCase {
+  constructor(private membershipRepo: HouseholdMembershipRepository) {}
+
+  async execute(
+    adminUserId: string,
+    householdId: string,
+    memberId: string,
+  ): Promise<void> {
+    const admin = await this.membershipRepo.findByUserAndHousehold(
+      adminUserId,
+      householdId,
+    );
+    if (
+      !admin ||
+      admin.role !== MembershipRole.ADMIN ||
+      admin.status !== MembershipStatus.ACTIVE
+    ) {
+      throw new Error('No autorizado');
+    }
+
+    const target = await this.membershipRepo.findById(memberId);
+    if (!target || target.householdId !== householdId) {
+      throw new Error('Membresía no encontrada');
+    }
+
+    await this.membershipRepo.updateStatus(target.id, MembershipStatus.REVOKED);
+  }
+}

--- a/Backend/src/infrastructure/persistence/models/household-membership.schema.ts
+++ b/Backend/src/infrastructure/persistence/models/household-membership.schema.ts
@@ -1,0 +1,26 @@
+import { Schema, model, Document } from 'mongoose';
+import { HouseholdMembership } from '../../../domain/models/household-membership.model';
+import { MembershipRole } from '../../../domain/models/enums/membership-role.enum';
+import { MembershipStatus } from '../../../domain/models/enums/membership-status.enum';
+
+interface HouseholdMembershipDocument
+  extends Document,
+    Omit<HouseholdMembership, 'id'> {}
+
+const HouseholdMembershipSchema = new Schema<HouseholdMembershipDocument>({
+  userId: { type: String, required: true },
+  householdId: { type: String, required: true },
+  role: { type: String, enum: Object.values(MembershipRole), required: true },
+  status: {
+    type: String,
+    enum: Object.values(MembershipStatus),
+    required: true,
+  },
+  joinedAt: { type: Date, default: Date.now },
+  invitedBy: { type: String },
+});
+
+export const HouseholdMembershipModel = model<HouseholdMembershipDocument>(
+  'HouseholdMembership',
+  HouseholdMembershipSchema,
+);

--- a/Backend/src/infrastructure/persistence/models/household.schema.ts
+++ b/Backend/src/infrastructure/persistence/models/household.schema.ts
@@ -1,0 +1,37 @@
+import { Schema, model, Document } from 'mongoose';
+import {
+  Household,
+  BudgetGoal,
+  HouseholdAlertsConfig,
+} from '../../../domain/models/household.model';
+
+interface HouseholdDocument extends Document, Omit<Household, 'id'> {}
+
+const BudgetGoalSchema = new Schema<BudgetGoal>({
+  amount: { type: Number, required: true },
+  targetDate: { type: Date },
+});
+
+const AlertsConfigSchema = new Schema<HouseholdAlertsConfig>({
+  budgetUsageThreshold: { type: Number },
+});
+
+const HouseholdSchema = new Schema<HouseholdDocument>({
+  name: { type: String, required: true },
+  baseCurrency: { type: String, required: true },
+  initialBudgetGoal: { type: BudgetGoalSchema },
+  monthlyBudgetGoal: { type: Number },
+  alertsConfig: { type: AlertsConfigSchema },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+HouseholdSchema.pre('save', function (next) {
+  this.updatedAt = new Date();
+  next();
+});
+
+export const HouseholdModel = model<HouseholdDocument>(
+  'Household',
+  HouseholdSchema,
+);

--- a/Backend/src/infrastructure/persistence/models/invitation.schema.ts
+++ b/Backend/src/infrastructure/persistence/models/invitation.schema.ts
@@ -1,0 +1,26 @@
+import { Schema, model, Document } from 'mongoose';
+import { Invitation } from '../../../domain/models/invitation.model';
+import { InvitationStatus } from '../../../domain/models/enums/invitation-status.enum';
+
+interface InvitationDocument extends Document, Omit<Invitation, 'id'> {}
+
+const InvitationSchema = new Schema<InvitationDocument>({
+  householdId: { type: String, required: true },
+  email: { type: String },
+  token: { type: String, required: true, unique: true },
+  createdAt: { type: Date, default: Date.now },
+  expiresAt: { type: Date },
+  status: {
+    type: String,
+    enum: Object.values(InvitationStatus),
+    required: true,
+  },
+  invitedBy: { type: String, required: true },
+  medium: { type: String },
+  usageAttempts: { type: Number, default: 0 },
+});
+
+export const InvitationModel = model<InvitationDocument>(
+  'Invitation',
+  InvitationSchema,
+);

--- a/Backend/src/infrastructure/persistence/repositories/household-membership.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/household-membership.repository.ts
@@ -1,0 +1,44 @@
+import { HouseholdMembership } from '../../../domain/models/household-membership.model';
+import { HouseholdMembershipModel } from '../models/household-membership.schema';
+import { MembershipStatus } from '../../../domain/models/enums/membership-status.enum';
+
+export class HouseholdMembershipRepository {
+  async create(
+    membership: Omit<HouseholdMembership, 'id'>,
+  ): Promise<HouseholdMembership> {
+    const created = await HouseholdMembershipModel.create(membership);
+    return {
+      id: created.id,
+      ...created.toObject(),
+    } as unknown as HouseholdMembership;
+  }
+
+  async findByUserAndHousehold(
+    userId: string,
+    householdId: string,
+  ): Promise<HouseholdMembership | null> {
+    return (await HouseholdMembershipModel.findOne({
+      userId,
+      householdId,
+    }).lean()) as HouseholdMembership | null;
+  }
+
+  async findById(id: string): Promise<HouseholdMembership | null> {
+    return (await HouseholdMembershipModel.findById(
+      id,
+    ).lean()) as HouseholdMembership | null;
+  }
+
+  async updateStatus(
+    id: string,
+    status: MembershipStatus,
+  ): Promise<HouseholdMembership | null> {
+    const update: Partial<HouseholdMembership> = { status };
+    if (status === MembershipStatus.ACTIVE) {
+      update.joinedAt = new Date();
+    }
+    return (await HouseholdMembershipModel.findByIdAndUpdate(id, update, {
+      new: true,
+    }).lean()) as HouseholdMembership | null;
+  }
+}

--- a/Backend/src/infrastructure/persistence/repositories/household.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/household.repository.ts
@@ -1,0 +1,13 @@
+import { Household } from '../../../domain/models/household.model';
+import { HouseholdModel } from '../models/household.schema';
+
+export class HouseholdRepository {
+  async create(household: Omit<Household, 'id'>): Promise<Household> {
+    const created = await HouseholdModel.create(household);
+    return { id: created.id, ...created.toObject() } as unknown as Household;
+  }
+
+  async findById(id: string): Promise<Household | null> {
+    return (await HouseholdModel.findById(id).lean()) as Household | null;
+  }
+}

--- a/Backend/src/infrastructure/persistence/repositories/invitation.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/invitation.repository.ts
@@ -1,0 +1,24 @@
+import { Invitation } from '../../../domain/models/invitation.model';
+import { InvitationModel } from '../models/invitation.schema';
+
+export class InvitationRepository {
+  async create(invitation: Omit<Invitation, 'id'>): Promise<Invitation> {
+    const created = await InvitationModel.create(invitation);
+    return { id: created.id, ...created.toObject() } as unknown as Invitation;
+  }
+
+  async findByToken(token: string): Promise<Invitation | null> {
+    return (await InvitationModel.findOne({
+      token,
+    }).lean()) as Invitation | null;
+  }
+
+  async update(
+    id: string,
+    update: Partial<Invitation>,
+  ): Promise<Invitation | null> {
+    return (await InvitationModel.findByIdAndUpdate(id, update, {
+      new: true,
+    }).lean()) as Invitation | null;
+  }
+}

--- a/Backend/src/interfaces/http/controllers/auth.controller.ts
+++ b/Backend/src/interfaces/http/controllers/auth.controller.ts
@@ -44,7 +44,10 @@ export class AuthController {
 
   linkGoogleAccount = async (req: Request, res: Response) => {
     const { idToken } = req.body as GoogleRequestDto;
-    const user = await this.linkGoogle.execute((req as AuthRequest).userId, idToken);
+    const user = await this.linkGoogle.execute(
+      (req as AuthRequest).userId,
+      idToken,
+    );
     res.json({ user });
   };
 }

--- a/Backend/src/interfaces/http/controllers/household.controller.ts
+++ b/Backend/src/interfaces/http/controllers/household.controller.ts
@@ -1,0 +1,53 @@
+import { Request, Response } from 'express';
+import { CreateHouseholdUseCase } from '../../../application/use-cases/create-household.usecase';
+import { InviteToHouseholdUseCase } from '../../../application/use-cases/invite-to-household.usecase';
+import { RevokeMembershipUseCase } from '../../../application/use-cases/revoke-membership.usecase';
+import {
+  CreateHouseholdRequestDto,
+  InviteRequestDto,
+} from '../dto/household.dto';
+
+interface AuthRequest extends Request {
+  userId: string;
+}
+
+export class HouseholdController {
+  constructor(
+    private createHousehold: CreateHouseholdUseCase,
+    private inviteToHousehold: InviteToHouseholdUseCase,
+    private revokeMembership: RevokeMembershipUseCase,
+  ) {}
+
+  create = async (req: Request, res: Response) => {
+    const { name, baseCurrency } = req.body as CreateHouseholdRequestDto;
+    const userId = (req as AuthRequest).userId;
+    const household = await this.createHousehold.execute(
+      userId,
+      name,
+      baseCurrency,
+    );
+    res.status(201).json({ household });
+  };
+
+  invite = async (req: Request, res: Response) => {
+    const { email } = req.body as InviteRequestDto;
+    const { householdId } = req.params as { householdId: string };
+    const userId = (req as AuthRequest).userId;
+    const invitation = await this.inviteToHousehold.execute(
+      userId,
+      householdId,
+      email,
+    );
+    res.status(201).json({ invitation });
+  };
+
+  revokeMember = async (req: Request, res: Response) => {
+    const { householdId, memberId } = req.params as {
+      householdId: string;
+      memberId: string;
+    };
+    const userId = (req as AuthRequest).userId;
+    await this.revokeMembership.execute(userId, householdId, memberId);
+    res.status(204).send();
+  };
+}

--- a/Backend/src/interfaces/http/controllers/invitation.controller.ts
+++ b/Backend/src/interfaces/http/controllers/invitation.controller.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from 'express';
+import { AcceptInvitationUseCase } from '../../../application/use-cases/accept-invitation.usecase';
+import { AcceptInvitationRequestDto } from '../dto/household.dto';
+
+interface AuthRequest extends Request {
+  userId: string;
+}
+
+export class InvitationController {
+  constructor(private acceptInvitation: AcceptInvitationUseCase) {}
+
+  accept = async (req: Request, res: Response) => {
+    const { token } = req.body as AcceptInvitationRequestDto;
+    const userId = (req as AuthRequest).userId;
+    const membership = await this.acceptInvitation.execute(token, userId);
+    res.json({ membership });
+  };
+}

--- a/Backend/src/interfaces/http/dto/household.dto.ts
+++ b/Backend/src/interfaces/http/dto/household.dto.ts
@@ -1,0 +1,12 @@
+export interface CreateHouseholdRequestDto {
+  name: string;
+  baseCurrency: string;
+}
+
+export interface InviteRequestDto {
+  email: string;
+}
+
+export interface AcceptInvitationRequestDto {
+  token: string;
+}

--- a/Backend/src/interfaces/http/routes/household.routes.ts
+++ b/Backend/src/interfaces/http/routes/household.routes.ts
@@ -1,0 +1,50 @@
+import { Router } from 'express';
+import { HouseholdController } from '../controllers/household.controller';
+import { HouseholdRepository } from '../../../infrastructure/persistence/repositories/household.repository';
+import { HouseholdMembershipRepository } from '../../../infrastructure/persistence/repositories/household-membership.repository';
+import { InvitationRepository } from '../../../infrastructure/persistence/repositories/invitation.repository';
+import { UserRepository } from '../../../infrastructure/persistence/repositories/user.repository';
+import { JwtService } from '../../../infrastructure/auth/jwt.service';
+import { authMiddleware } from '../../middleware/auth.middleware';
+import { CreateHouseholdUseCase } from '../../../application/use-cases/create-household.usecase';
+import { InviteToHouseholdUseCase } from '../../../application/use-cases/invite-to-household.usecase';
+import { RevokeMembershipUseCase } from '../../../application/use-cases/revoke-membership.usecase';
+
+const router = Router();
+
+const householdRepo = new HouseholdRepository();
+const membershipRepo = new HouseholdMembershipRepository();
+const invitationRepo = new InvitationRepository();
+const userRepo = new UserRepository();
+const jwtService = new JwtService();
+
+const createHousehold = new CreateHouseholdUseCase(
+  householdRepo,
+  membershipRepo,
+);
+const inviteToHousehold = new InviteToHouseholdUseCase(
+  membershipRepo,
+  invitationRepo,
+  userRepo,
+);
+const revokeMembership = new RevokeMembershipUseCase(membershipRepo);
+
+const controller = new HouseholdController(
+  createHousehold,
+  inviteToHousehold,
+  revokeMembership,
+);
+
+router.post('/', authMiddleware(jwtService), controller.create);
+router.post(
+  '/:householdId/invitations',
+  authMiddleware(jwtService),
+  controller.invite,
+);
+router.delete(
+  '/:householdId/members/:memberId',
+  authMiddleware(jwtService),
+  controller.revokeMember,
+);
+
+export default router;

--- a/Backend/src/interfaces/http/routes/invitation.routes.ts
+++ b/Backend/src/interfaces/http/routes/invitation.routes.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import { InvitationController } from '../controllers/invitation.controller';
+import { InvitationRepository } from '../../../infrastructure/persistence/repositories/invitation.repository';
+import { HouseholdMembershipRepository } from '../../../infrastructure/persistence/repositories/household-membership.repository';
+import { JwtService } from '../../../infrastructure/auth/jwt.service';
+import { authMiddleware } from '../../middleware/auth.middleware';
+import { AcceptInvitationUseCase } from '../../../application/use-cases/accept-invitation.usecase';
+
+const router = Router();
+
+const invitationRepo = new InvitationRepository();
+const membershipRepo = new HouseholdMembershipRepository();
+const jwtService = new JwtService();
+
+const acceptInvitation = new AcceptInvitationUseCase(
+  invitationRepo,
+  membershipRepo,
+);
+
+const controller = new InvitationController(acceptInvitation);
+
+router.post('/accept', authMiddleware(jwtService), controller.accept);
+
+export default router;

--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -2,6 +2,8 @@ import express from 'express';
 import { config } from './config/env';
 import { connectMongo } from './infrastructure/persistence/mongoose-connection';
 import authRoutes from './interfaces/http/routes/auth.routes';
+import householdRoutes from './interfaces/http/routes/household.routes';
+import invitationRoutes from './interfaces/http/routes/invitation.routes';
 
 const app = express();
 app.use(express.json());
@@ -11,6 +13,8 @@ connectMongo()
   .catch((err) => console.error('Error de conexión con MongoDB', err));
 
 app.use('/api/v1/auth', authRoutes);
+app.use('/api/v1/households', householdRoutes);
+app.use('/api/v1/invitations', invitationRoutes);
 
 app.get('/', (_req, res) => {
   res.send('API de Nidify');


### PR DESCRIPTION
## Summary
- add household, membership and invitation persistence layers
- implement use cases for creating households, inviting members and accepting or revoking memberships
- expose HTTP endpoints for household management and invitation acceptance

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fecb516a883268a349320c74a149d