### PR TITLE
feat: add item management

### DIFF
--- a/Backend/src/application/use-cases/create-item.usecase.ts
+++ b/Backend/src/application/use-cases/create-item.usecase.ts
@@ -1,0 +1,45 @@
+import { Item } from '../../domain/models/item.model';
+import { ItemRepository } from '../../infrastructure/persistence/repositories/item.repository';
+import { ItemPriority } from '../../domain/models/enums/item-priority.enum';
+import { ItemStatus } from '../../domain/models/enums/item-status.enum';
+import { ItemType } from '../../domain/models/enums/item-type.enum';
+import { PaymentSplit } from '../../domain/models/payment-split.model';
+
+export interface CreateItemPayload {
+  name: string;
+  description?: string;
+  categoryId?: string;
+  type: ItemType;
+  price: number;
+  currency: string;
+  purchaseLink?: string;
+  imageUrls?: string[];
+  status: ItemStatus;
+  priority: ItemPriority;
+  paymentSplit?: PaymentSplit;
+  estimatedPurchaseDate?: Date;
+  purchasedAt?: Date;
+  tags?: string[];
+  lastModifiedByName?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export class CreateItemUseCase {
+  constructor(private itemRepo: ItemRepository) {}
+
+  async execute(
+    userId: string,
+    householdId: string,
+    payload: CreateItemPayload,
+  ): Promise<Item> {
+    const now = new Date();
+    const item: Omit<Item, 'id'> = {
+      householdId,
+      ...payload,
+      createdAt: now,
+      updatedAt: now,
+      lastModifiedBy: userId,
+    };
+    return this.itemRepo.create(item);
+  }
+}

--- a/Backend/src/application/use-cases/delete-item.usecase.ts
+++ b/Backend/src/application/use-cases/delete-item.usecase.ts
@@ -1,0 +1,9 @@
+import { ItemRepository } from '../../infrastructure/persistence/repositories/item.repository';
+
+export class DeleteItemUseCase {
+  constructor(private itemRepo: ItemRepository) {}
+
+  async execute(itemId: string): Promise<void> {
+    await this.itemRepo.delete(itemId);
+  }
+}

--- a/Backend/src/application/use-cases/list-items.usecase.ts
+++ b/Backend/src/application/use-cases/list-items.usecase.ts
@@ -1,0 +1,10 @@
+import { Item } from '../../domain/models/item.model';
+import { ItemRepository } from '../../infrastructure/persistence/repositories/item.repository';
+
+export class ListItemsUseCase {
+  constructor(private itemRepo: ItemRepository) {}
+
+  async execute(householdId: string): Promise<Item[]> {
+    return this.itemRepo.findByHousehold(householdId);
+  }
+}

--- a/Backend/src/application/use-cases/update-item.usecase.ts
+++ b/Backend/src/application/use-cases/update-item.usecase.ts
@@ -1,0 +1,42 @@
+import { Item } from '../../domain/models/item.model';
+import { ItemRepository } from '../../infrastructure/persistence/repositories/item.repository';
+import { ItemPriority } from '../../domain/models/enums/item-priority.enum';
+import { ItemStatus } from '../../domain/models/enums/item-status.enum';
+import { ItemType } from '../../domain/models/enums/item-type.enum';
+import { PaymentSplit } from '../../domain/models/payment-split.model';
+
+export interface UpdateItemPayload {
+  name?: string;
+  description?: string;
+  categoryId?: string;
+  type?: ItemType;
+  price?: number;
+  currency?: string;
+  purchaseLink?: string;
+  imageUrls?: string[];
+  status?: ItemStatus;
+  priority?: ItemPriority;
+  paymentSplit?: PaymentSplit;
+  estimatedPurchaseDate?: Date;
+  purchasedAt?: Date;
+  tags?: string[];
+  lastModifiedByName?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export class UpdateItemUseCase {
+  constructor(private itemRepo: ItemRepository) {}
+
+  async execute(
+    userId: string,
+    itemId: string,
+    payload: UpdateItemPayload,
+  ): Promise<Item | null> {
+    const update: Partial<Item> = {
+      ...payload,
+      lastModifiedBy: userId,
+      updatedAt: new Date(),
+    };
+    return this.itemRepo.update(itemId, update);
+  }
+}

--- a/Backend/src/infrastructure/persistence/models/item.schema.ts
+++ b/Backend/src/infrastructure/persistence/models/item.schema.ts
@@ -1,0 +1,57 @@
+import { Schema, model, Document } from 'mongoose';
+import { Item } from '../../../domain/models/item.model';
+import { ItemType } from '../../../domain/models/enums/item-type.enum';
+import { ItemStatus } from '../../../domain/models/enums/item-status.enum';
+import { ItemPriority } from '../../../domain/models/enums/item-priority.enum';
+
+interface ItemDocument extends Document, Omit<Item, 'id'> {}
+
+const PaymentAssignmentSchema = new Schema({
+  userId: { type: String, required: true },
+  percentage: { type: Number },
+  amount: { type: Number },
+  calculatedAmount: { type: Number, required: true },
+  label: { type: String },
+});
+
+const PaymentSplitSchema = new Schema({
+  assignments: { type: [PaymentAssignmentSchema], default: [] },
+});
+
+const ItemSchema = new Schema<ItemDocument>({
+  householdId: { type: String, required: true },
+  name: { type: String, required: true },
+  description: { type: String },
+  categoryId: { type: String },
+  type: { type: String, enum: Object.values(ItemType), required: true },
+  price: { type: Number, required: true },
+  currency: { type: String, required: true },
+  purchaseLink: { type: String },
+  imageUrls: { type: [String], default: [] },
+  status: {
+    type: String,
+    enum: Object.values(ItemStatus),
+    default: ItemStatus.TO_QUOTE,
+  },
+  priority: {
+    type: String,
+    enum: Object.values(ItemPriority),
+    default: ItemPriority.NECESSARY,
+  },
+  paymentSplit: { type: PaymentSplitSchema },
+  estimatedPurchaseDate: { type: Date },
+  purchasedAt: { type: Date },
+  tags: { type: [String], default: [] },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+  lastModifiedBy: { type: String, required: true },
+  lastModifiedByName: { type: String },
+  metadata: { type: Schema.Types.Mixed },
+});
+
+ItemSchema.pre('save', function (next) {
+  this.updatedAt = new Date();
+  next();
+});
+
+export const ItemModel = model<ItemDocument>('Item', ItemSchema);

--- a/Backend/src/infrastructure/persistence/repositories/item.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/item.repository.ts
@@ -1,0 +1,28 @@
+import { Item } from '../../../domain/models/item.model';
+import { ItemModel } from '../models/item.schema';
+
+export class ItemRepository {
+  async findById(id: string): Promise<Item | null> {
+    return (await ItemModel.findById(id).lean()) as Item | null;
+  }
+
+  async findByHousehold(householdId: string): Promise<Item[]> {
+    return (await ItemModel.find({ householdId }).lean()) as Item[];
+  }
+
+  async create(item: Omit<Item, 'id'>): Promise<Item> {
+    const created = await ItemModel.create(item);
+    return { id: created.id, ...created.toObject() } as unknown as Item;
+  }
+
+  async update(id: string, update: Partial<Item>): Promise<Item | null> {
+    const updated = await ItemModel.findByIdAndUpdate(id, update, {
+      new: true,
+    }).lean();
+    return updated as Item | null;
+  }
+
+  async delete(id: string): Promise<void> {
+    await ItemModel.findByIdAndDelete(id);
+  }
+}

--- a/Backend/src/interfaces/http/controllers/item.controller.ts
+++ b/Backend/src/interfaces/http/controllers/item.controller.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from 'express';
+import { CreateItemUseCase } from '../../../application/use-cases/create-item.usecase';
+import { ListItemsUseCase } from '../../../application/use-cases/list-items.usecase';
+import { UpdateItemUseCase } from '../../../application/use-cases/update-item.usecase';
+import { DeleteItemUseCase } from '../../../application/use-cases/delete-item.usecase';
+import { CreateItemRequestDto, UpdateItemRequestDto } from '../dto/item.dto';
+
+interface AuthRequest extends Request {
+  userId: string;
+}
+
+export class ItemController {
+  constructor(
+    private createItem: CreateItemUseCase,
+    private listItems: ListItemsUseCase,
+    private updateItem: UpdateItemUseCase,
+    private deleteItem: DeleteItemUseCase,
+  ) {}
+
+  list = async (req: Request, res: Response) => {
+    const { householdId } = req.params as { householdId: string };
+    const items = await this.listItems.execute(householdId);
+    res.json({ items });
+  };
+
+  create = async (req: Request, res: Response) => {
+    const { householdId } = req.params as { householdId: string };
+    const userId = (req as AuthRequest).userId;
+    const payload = req.body as CreateItemRequestDto;
+    const item = await this.createItem.execute(userId, householdId, payload);
+    res.status(201).json({ item });
+  };
+
+  update = async (req: Request, res: Response) => {
+    const { itemId } = req.params as { itemId: string };
+    const userId = (req as AuthRequest).userId;
+    const payload = req.body as UpdateItemRequestDto;
+    const item = await this.updateItem.execute(userId, itemId, payload);
+    res.json({ item });
+  };
+
+  delete = async (req: Request, res: Response) => {
+    const { itemId } = req.params as { itemId: string };
+    await this.deleteItem.execute(itemId);
+    res.status(204).send();
+  };
+}

--- a/Backend/src/interfaces/http/dto/item.dto.ts
+++ b/Backend/src/interfaces/http/dto/item.dto.ts
@@ -1,0 +1,25 @@
+import { ItemPriority } from '../../../domain/models/enums/item-priority.enum';
+import { ItemStatus } from '../../../domain/models/enums/item-status.enum';
+import { ItemType } from '../../../domain/models/enums/item-type.enum';
+import { PaymentSplit } from '../../../domain/models/payment-split.model';
+
+export interface CreateItemRequestDto {
+  name: string;
+  description?: string;
+  categoryId?: string;
+  type: ItemType;
+  price: number;
+  currency: string;
+  purchaseLink?: string;
+  imageUrls?: string[];
+  status: ItemStatus;
+  priority: ItemPriority;
+  paymentSplit?: PaymentSplit;
+  estimatedPurchaseDate?: Date;
+  purchasedAt?: Date;
+  tags?: string[];
+  lastModifiedByName?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type UpdateItemRequestDto = Partial<CreateItemRequestDto>;

--- a/Backend/src/interfaces/http/routes/item.routes.ts
+++ b/Backend/src/interfaces/http/routes/item.routes.ts
@@ -1,0 +1,33 @@
+import { Router } from 'express';
+import { ItemRepository } from '../../../infrastructure/persistence/repositories/item.repository';
+import { JwtService } from '../../../infrastructure/auth/jwt.service';
+import { authMiddleware } from '../../middleware/auth.middleware';
+import { CreateItemUseCase } from '../../../application/use-cases/create-item.usecase';
+import { ListItemsUseCase } from '../../../application/use-cases/list-items.usecase';
+import { UpdateItemUseCase } from '../../../application/use-cases/update-item.usecase';
+import { DeleteItemUseCase } from '../../../application/use-cases/delete-item.usecase';
+import { ItemController } from '../controllers/item.controller';
+
+const router = Router({ mergeParams: true });
+
+const itemRepo = new ItemRepository();
+const jwtService = new JwtService();
+
+const createItem = new CreateItemUseCase(itemRepo);
+const listItems = new ListItemsUseCase(itemRepo);
+const updateItem = new UpdateItemUseCase(itemRepo);
+const deleteItem = new DeleteItemUseCase(itemRepo);
+
+const controller = new ItemController(
+  createItem,
+  listItems,
+  updateItem,
+  deleteItem,
+);
+
+router.get('/', authMiddleware(jwtService), controller.list);
+router.post('/', authMiddleware(jwtService), controller.create);
+router.put('/:itemId', authMiddleware(jwtService), controller.update);
+router.delete('/:itemId', authMiddleware(jwtService), controller.delete);
+
+export default router;

--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -4,6 +4,7 @@ import { connectMongo } from './infrastructure/persistence/mongoose-connection';
 import authRoutes from './interfaces/http/routes/auth.routes';
 import householdRoutes from './interfaces/http/routes/household.routes';
 import invitationRoutes from './interfaces/http/routes/invitation.routes';
+import itemRoutes from './interfaces/http/routes/item.routes';
 
 const app = express();
 app.use(express.json());
@@ -15,6 +16,7 @@ connectMongo()
 app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/households', householdRoutes);
 app.use('/api/v1/invitations', invitationRoutes);
+app.use('/api/v1/households/:householdId/items', itemRoutes);
 
 app.get('/', (_req, res) => {
   res.send('API de Nidify');


### PR DESCRIPTION
## Summary
- add item persistence schema and repository
- implement item CRUD use cases and HTTP layer
- expose household item routes

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688ff5b1cf108326b97f7857d2046dd5