### PR TITLE
Add household budget management

### DIFF
--- a/Backend/src/application/use-cases/get-budget-summary.usecase.ts
+++ b/Backend/src/application/use-cases/get-budget-summary.usecase.ts
@@ -1,0 +1,72 @@
+import {
+  BudgetSummary,
+  MemberBudgetTotals,
+} from '../../domain/models/budget-summary.model';
+import { ItemType } from '../../domain/models/enums/item-type.enum';
+import { ItemStatus } from '../../domain/models/enums/item-status.enum';
+import { HouseholdRepository } from '../../infrastructure/persistence/repositories/household.repository';
+import { ItemRepository } from '../../infrastructure/persistence/repositories/item.repository';
+
+export class GetBudgetSummaryUseCase {
+  constructor(
+    private householdRepo: HouseholdRepository,
+    private itemRepo: ItemRepository,
+  ) {}
+
+  async execute(householdId: string): Promise<BudgetSummary | null> {
+    const household = await this.householdRepo.findById(householdId);
+    if (!household) return null;
+
+    const items = await this.itemRepo.findByHousehold(householdId);
+    let initialTotal = 0;
+    let monthlyTotal = 0;
+    const memberTotalsMap: Record<string, MemberBudgetTotals> = {};
+
+    for (const item of items) {
+      if (item.status === ItemStatus.DISCARDED) continue;
+      if (item.type === ItemType.ONE_TIME) {
+        initialTotal += item.price;
+      } else if (item.type === ItemType.RECURRING) {
+        monthlyTotal += item.price;
+      }
+      if (item.paymentSplit) {
+        for (const assignment of item.paymentSplit.assignments) {
+          if (!memberTotalsMap[assignment.userId]) {
+            memberTotalsMap[assignment.userId] = {
+              userId: assignment.userId,
+              initial: 0,
+              monthly: 0,
+            };
+          }
+          const totals = memberTotalsMap[assignment.userId]!;
+          if (item.type === ItemType.ONE_TIME) {
+            totals.initial += assignment.calculatedAmount;
+          } else if (item.type === ItemType.RECURRING) {
+            totals.monthly += assignment.calculatedAmount;
+          }
+        }
+      }
+    }
+
+    const memberTotals = Object.values(memberTotalsMap);
+    const initialGoal = household.initialBudgetGoal?.amount;
+    const monthlyGoal = household.monthlyBudgetGoal;
+
+    const summary: BudgetSummary = {
+      householdId,
+      currency: household.baseCurrency,
+      initialTotal,
+      monthlyTotal,
+      memberTotals,
+      initialExceeded: initialGoal ? initialTotal > initialGoal : false,
+      monthlyExceeded: monthlyGoal ? monthlyTotal > monthlyGoal : false,
+    };
+    if (initialGoal !== undefined) {
+      summary.initialGoal = initialGoal;
+    }
+    if (monthlyGoal !== undefined) {
+      summary.monthlyGoal = monthlyGoal;
+    }
+    return summary;
+  }
+}

--- a/Backend/src/application/use-cases/update-budget-goal.usecase.ts
+++ b/Backend/src/application/use-cases/update-budget-goal.usecase.ts
@@ -1,0 +1,58 @@
+import { BudgetGoalType } from '../../domain/models/enums/budget-goal-type.enum';
+import { Household } from '../../domain/models/household.model';
+import { BudgetChangeRepository } from '../../infrastructure/persistence/repositories/budget-change.repository';
+import { HouseholdRepository } from '../../infrastructure/persistence/repositories/household.repository';
+
+export interface UpdateBudgetGoalPayload {
+  amount: number;
+  targetDate?: Date;
+  reason?: string;
+}
+
+export class UpdateBudgetGoalUseCase {
+  constructor(
+    private householdRepo: HouseholdRepository,
+    private changeRepo: BudgetChangeRepository,
+  ) {}
+
+  async execute(
+    userId: string,
+    householdId: string,
+    type: BudgetGoalType,
+    payload: UpdateBudgetGoalPayload,
+  ): Promise<Household | null> {
+    const household = await this.householdRepo.findById(householdId);
+    if (!household) return null;
+
+    const previousAmount =
+      type === BudgetGoalType.INITIAL
+        ? household.initialBudgetGoal?.amount || 0
+        : household.monthlyBudgetGoal || 0;
+
+    const update: Partial<Household> = {};
+    if (type === BudgetGoalType.INITIAL) {
+      const goal: Household['initialBudgetGoal'] = { amount: payload.amount };
+      if (payload.targetDate) {
+        goal.targetDate = payload.targetDate;
+      }
+      update.initialBudgetGoal = goal;
+    } else {
+      update.monthlyBudgetGoal = payload.amount;
+    }
+
+    const updated = await this.householdRepo.update(householdId, update);
+
+    await this.changeRepo.create({
+      householdId,
+      type,
+      previousAmount,
+      newAmount: payload.amount,
+      currency: household.baseCurrency,
+      userId,
+      timestamp: new Date(),
+      ...(payload.reason ? { reason: payload.reason } : {}),
+    });
+
+    return updated;
+  }
+}

--- a/Backend/src/domain/models/budget-summary.model.ts
+++ b/Backend/src/domain/models/budget-summary.model.ts
@@ -1,0 +1,17 @@
+export interface MemberBudgetTotals {
+  userId: string;
+  initial: number;
+  monthly: number;
+}
+
+export interface BudgetSummary {
+  householdId: string;
+  currency: string;
+  initialTotal: number;
+  monthlyTotal: number;
+  memberTotals: MemberBudgetTotals[];
+  initialGoal?: number;
+  monthlyGoal?: number;
+  initialExceeded: boolean;
+  monthlyExceeded: boolean;
+}

--- a/Backend/src/infrastructure/persistence/models/budget-change.schema.ts
+++ b/Backend/src/infrastructure/persistence/models/budget-change.schema.ts
@@ -1,0 +1,20 @@
+import { Schema, model, Document } from 'mongoose';
+import { BudgetChange } from '../../../domain/models/budget-change.model';
+
+interface BudgetChangeDocument extends Document, Omit<BudgetChange, 'id'> {}
+
+const BudgetChangeSchema = new Schema<BudgetChangeDocument>({
+  householdId: { type: String, required: true },
+  type: { type: String, required: true },
+  previousAmount: { type: Number, required: true },
+  newAmount: { type: Number, required: true },
+  currency: { type: String, required: true },
+  userId: { type: String, required: true },
+  timestamp: { type: Date, default: Date.now },
+  reason: { type: String },
+});
+
+export const BudgetChangeModel = model<BudgetChangeDocument>(
+  'BudgetChange',
+  BudgetChangeSchema,
+);

--- a/Backend/src/infrastructure/persistence/repositories/budget-change.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/budget-change.repository.ts
@@ -1,0 +1,15 @@
+import { BudgetChange } from '../../../domain/models/budget-change.model';
+import { BudgetChangeModel } from '../models/budget-change.schema';
+
+export class BudgetChangeRepository {
+  async create(change: Omit<BudgetChange, 'id'>): Promise<BudgetChange> {
+    const created = await BudgetChangeModel.create(change);
+    return { id: created.id, ...created.toObject() } as unknown as BudgetChange;
+  }
+
+  async findByHousehold(householdId: string): Promise<BudgetChange[]> {
+    return (await BudgetChangeModel.find({ householdId })
+      .sort({ timestamp: -1 })
+      .lean()) as BudgetChange[];
+  }
+}

--- a/Backend/src/infrastructure/persistence/repositories/household.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/household.repository.ts
@@ -10,4 +10,14 @@ export class HouseholdRepository {
   async findById(id: string): Promise<Household | null> {
     return (await HouseholdModel.findById(id).lean()) as Household | null;
   }
+
+  async update(
+    id: string,
+    update: Partial<Household>,
+  ): Promise<Household | null> {
+    const updated = await HouseholdModel.findByIdAndUpdate(id, update, {
+      new: true,
+    }).lean();
+    return updated as Household | null;
+  }
 }

--- a/Backend/src/interfaces/http/controllers/budget.controller.ts
+++ b/Backend/src/interfaces/http/controllers/budget.controller.ts
@@ -1,0 +1,54 @@
+import { Request, Response } from 'express';
+import { GetBudgetSummaryUseCase } from '../../../application/use-cases/get-budget-summary.usecase';
+import {
+  UpdateBudgetGoalUseCase,
+  UpdateBudgetGoalPayload,
+} from '../../../application/use-cases/update-budget-goal.usecase';
+import { BudgetGoalType } from '../../../domain/models/enums/budget-goal-type.enum';
+import { UpdateBudgetRequestDto } from '../dto/budget.dto';
+
+interface AuthRequest extends Request {
+  userId: string;
+}
+
+export class BudgetController {
+  constructor(
+    private getSummary: GetBudgetSummaryUseCase,
+    private updateGoal: UpdateBudgetGoalUseCase,
+  ) {}
+
+  summary = async (req: Request, res: Response) => {
+    const { householdId } = req.params as { householdId: string };
+    const summary = await this.getSummary.execute(householdId);
+    if (!summary) {
+      return res.status(404).json({ error: 'Household not found' });
+    }
+    res.json({ summary });
+  };
+
+  update = async (req: Request, res: Response) => {
+    const { householdId, type } = req.params as {
+      householdId: string;
+      type: BudgetGoalType;
+    };
+    const userId = (req as AuthRequest).userId;
+    const payload = req.body as UpdateBudgetRequestDto;
+    const updatePayload: UpdateBudgetGoalPayload = { amount: payload.amount };
+    if (payload.targetDate) {
+      updatePayload.targetDate = new Date(payload.targetDate);
+    }
+    if (payload.reason) {
+      updatePayload.reason = payload.reason;
+    }
+    const result = await this.updateGoal.execute(
+      userId,
+      householdId,
+      type,
+      updatePayload,
+    );
+    if (!result) {
+      return res.status(404).json({ error: 'Household not found' });
+    }
+    res.status(204).send();
+  };
+}

--- a/Backend/src/interfaces/http/dto/budget.dto.ts
+++ b/Backend/src/interfaces/http/dto/budget.dto.ts
@@ -1,0 +1,5 @@
+export interface UpdateBudgetRequestDto {
+  amount: number;
+  targetDate?: string;
+  reason?: string;
+}

--- a/Backend/src/interfaces/http/routes/budget.routes.ts
+++ b/Backend/src/interfaces/http/routes/budget.routes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { BudgetController } from '../controllers/budget.controller';
+import { HouseholdRepository } from '../../../infrastructure/persistence/repositories/household.repository';
+import { ItemRepository } from '../../../infrastructure/persistence/repositories/item.repository';
+import { BudgetChangeRepository } from '../../../infrastructure/persistence/repositories/budget-change.repository';
+import { GetBudgetSummaryUseCase } from '../../../application/use-cases/get-budget-summary.usecase';
+import { UpdateBudgetGoalUseCase } from '../../../application/use-cases/update-budget-goal.usecase';
+import { JwtService } from '../../../infrastructure/auth/jwt.service';
+import { authMiddleware } from '../../middleware/auth.middleware';
+
+const router = Router({ mergeParams: true });
+
+const householdRepo = new HouseholdRepository();
+const itemRepo = new ItemRepository();
+const changeRepo = new BudgetChangeRepository();
+const getSummary = new GetBudgetSummaryUseCase(householdRepo, itemRepo);
+const updateGoal = new UpdateBudgetGoalUseCase(householdRepo, changeRepo);
+const controller = new BudgetController(getSummary, updateGoal);
+
+const jwtService = new JwtService();
+
+router.get('/', authMiddleware(jwtService), controller.summary);
+router.put('/:type', authMiddleware(jwtService), controller.update);
+
+export default router;

--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -5,6 +5,7 @@ import authRoutes from './interfaces/http/routes/auth.routes';
 import householdRoutes from './interfaces/http/routes/household.routes';
 import invitationRoutes from './interfaces/http/routes/invitation.routes';
 import itemRoutes from './interfaces/http/routes/item.routes';
+import budgetRoutes from './interfaces/http/routes/budget.routes';
 
 const app = express();
 app.use(express.json());
@@ -17,6 +18,7 @@ app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/households', householdRoutes);
 app.use('/api/v1/invitations', invitationRoutes);
 app.use('/api/v1/households/:householdId/items', itemRoutes);
+app.use('/api/v1/households/:householdId/budget', budgetRoutes);
 
 app.get('/', (_req, res) => {
   res.send('API de Nidify');


### PR DESCRIPTION
## Summary
- implement budget summary and goal update use cases
- expose budget controller and routes with Mongo persistence
- include budget change logging and server wiring

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff89fce288326b96615a8ab116b9f