### PR TITLE
feat: add currency conversion with exchange rate caching

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -2,3 +2,5 @@ PORT=3000
 MONGODB_URI=mongodb://localhost:27017/nidify
 JWT_SECRET=changeme
 GOOGLE_CLIENT_ID=
+EXCHANGE_RATE_API_BASE=https://api.exchangerate.host
+EXCHANGE_RATE_TTL_MINUTES=60

--- a/Backend/src/application/use-cases/convert-currency.usecase.ts
+++ b/Backend/src/application/use-cases/convert-currency.usecase.ts
@@ -1,0 +1,58 @@
+import { ExchangeRate } from '../../domain/models/exchange-rate.model';
+import { ExchangeRateRepository } from '../../infrastructure/persistence/repositories/exchange-rate.repository';
+import { ExchangeRateProvider } from '../../infrastructure/currency/exchange-rate.provider';
+import { config } from '../../config/env';
+
+export interface ConvertCurrencyPayload {
+  amount: number;
+  from: string;
+  to: string;
+}
+
+export interface ConversionResult {
+  amount: number;
+  convertedAmount: number;
+  rate: number;
+  baseCurrency: string;
+  targetCurrency: string;
+  fetchedAt: Date;
+  source: string;
+}
+
+export class ConvertCurrencyUseCase {
+  constructor(
+    private repo: ExchangeRateRepository,
+    private provider: ExchangeRateProvider,
+  ) {}
+
+  private ttlMs = config.exchangeRateTtlMinutes * 60 * 1000;
+
+  async execute(payload: ConvertCurrencyPayload): Promise<ConversionResult> {
+    const { amount, from, to } = payload;
+    const now = new Date();
+    let rate: ExchangeRate | null = await this.repo.find(from, to);
+    if (!rate || (rate.expiresAt && rate.expiresAt <= now)) {
+      const fetched = await this.provider.fetchRate(from, to);
+      rate = {
+        id: `${from}_${to}`,
+        baseCurrency: from,
+        targetCurrency: to,
+        rate: fetched.rate,
+        fetchedAt: new Date(),
+        source: fetched.source,
+        expiresAt: new Date(Date.now() + this.ttlMs),
+      };
+      await this.repo.save(rate);
+    }
+    const convertedAmount = amount * rate.rate;
+    return {
+      amount,
+      convertedAmount,
+      rate: rate.rate,
+      baseCurrency: rate.baseCurrency,
+      targetCurrency: rate.targetCurrency,
+      fetchedAt: rate.fetchedAt,
+      source: rate.source,
+    };
+  }
+}

--- a/Backend/src/config/env.ts
+++ b/Backend/src/config/env.ts
@@ -7,4 +7,7 @@ export const config = {
   mongoUri: process.env.MONGODB_URI ?? 'mongodb://localhost:27017/nidify',
   jwtSecret: process.env.JWT_SECRET ?? 'changeme',
   googleClientId: process.env.GOOGLE_CLIENT_ID ?? '',
+  exchangeRateApiBase:
+    process.env.EXCHANGE_RATE_API_BASE ?? 'https://api.exchangerate.host',
+  exchangeRateTtlMinutes: Number(process.env.EXCHANGE_RATE_TTL_MINUTES ?? 60),
 };

--- a/Backend/src/infrastructure/currency/exchange-rate.provider.ts
+++ b/Backend/src/infrastructure/currency/exchange-rate.provider.ts
@@ -1,0 +1,29 @@
+import { config } from '../../config/env';
+
+interface FetchRateResult {
+  rate: number;
+  source: string;
+}
+
+export class ExchangeRateProvider {
+  constructor(private apiBase = config.exchangeRateApiBase) {}
+
+  async fetchRate(
+    baseCurrency: string,
+    targetCurrency: string,
+  ): Promise<FetchRateResult> {
+    const url = `${this.apiBase}/latest?base=${baseCurrency}&symbols=${targetCurrency}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error('Failed to fetch exchange rate');
+    }
+    const data = (await response.json()) as {
+      rates?: Record<string, number>;
+    };
+    const rate = data.rates?.[targetCurrency];
+    if (typeof rate !== 'number') {
+      throw new Error('Invalid exchange rate data');
+    }
+    return { rate, source: this.apiBase };
+  }
+}

--- a/Backend/src/infrastructure/persistence/models/exchange-rate.schema.ts
+++ b/Backend/src/infrastructure/persistence/models/exchange-rate.schema.ts
@@ -1,0 +1,23 @@
+import { Schema, model, Document } from 'mongoose';
+import { ExchangeRate } from '../../../domain/models/exchange-rate.model';
+
+interface ExchangeRateDocument extends Document, Omit<ExchangeRate, 'id'> {}
+
+const ExchangeRateSchema = new Schema<ExchangeRateDocument>({
+  baseCurrency: { type: String, required: true },
+  targetCurrency: { type: String, required: true },
+  rate: { type: Number, required: true },
+  fetchedAt: { type: Date, required: true },
+  source: { type: String, required: true },
+  expiresAt: { type: Date },
+});
+
+ExchangeRateSchema.index(
+  { baseCurrency: 1, targetCurrency: 1 },
+  { unique: true },
+);
+
+export const ExchangeRateModel = model<ExchangeRateDocument>(
+  'ExchangeRate',
+  ExchangeRateSchema,
+);

--- a/Backend/src/infrastructure/persistence/repositories/exchange-rate.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/exchange-rate.repository.ts
@@ -1,0 +1,26 @@
+import { ExchangeRate } from '../../../domain/models/exchange-rate.model';
+import { ExchangeRateModel } from '../models/exchange-rate.schema';
+
+export class ExchangeRateRepository {
+  async find(
+    baseCurrency: string,
+    targetCurrency: string,
+  ): Promise<ExchangeRate | null> {
+    return (await ExchangeRateModel.findOne({
+      baseCurrency,
+      targetCurrency,
+    }).lean()) as ExchangeRate | null;
+  }
+
+  async save(rate: ExchangeRate): Promise<ExchangeRate> {
+    await ExchangeRateModel.findOneAndUpdate(
+      {
+        baseCurrency: rate.baseCurrency,
+        targetCurrency: rate.targetCurrency,
+      },
+      rate,
+      { upsert: true },
+    );
+    return rate;
+  }
+}

--- a/Backend/src/interfaces/http/controllers/currency.controller.ts
+++ b/Backend/src/interfaces/http/controllers/currency.controller.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from 'express';
+import {
+  ConvertCurrencyUseCase,
+  ConvertCurrencyPayload,
+} from '../../../application/use-cases/convert-currency.usecase';
+
+export class CurrencyController {
+  constructor(private convertCurrency: ConvertCurrencyUseCase) {}
+
+  convert = async (req: Request, res: Response) => {
+    const { from, to, amount } = req.query as unknown as {
+      from: string;
+      to: string;
+      amount: string;
+    };
+    const payload: ConvertCurrencyPayload = {
+      from: from.toUpperCase(),
+      to: to.toUpperCase(),
+      amount: Number(amount),
+    };
+    const conversion = await this.convertCurrency.execute(payload);
+    res.json({ conversion });
+  };
+}

--- a/Backend/src/interfaces/http/dto/currency.dto.ts
+++ b/Backend/src/interfaces/http/dto/currency.dto.ts
@@ -1,0 +1,5 @@
+export interface ConvertCurrencyRequestDto {
+  from: string;
+  to: string;
+  amount: number;
+}

--- a/Backend/src/interfaces/http/routes/currency.routes.ts
+++ b/Backend/src/interfaces/http/routes/currency.routes.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { CurrencyController } from '../controllers/currency.controller';
+import { ExchangeRateRepository } from '../../../infrastructure/persistence/repositories/exchange-rate.repository';
+import { ExchangeRateProvider } from '../../../infrastructure/currency/exchange-rate.provider';
+import { ConvertCurrencyUseCase } from '../../../application/use-cases/convert-currency.usecase';
+
+const router = Router();
+
+const repo = new ExchangeRateRepository();
+const provider = new ExchangeRateProvider();
+const useCase = new ConvertCurrencyUseCase(repo, provider);
+const controller = new CurrencyController(useCase);
+
+router.get('/convert', controller.convert);
+
+export default router;

--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -6,6 +6,7 @@ import householdRoutes from './interfaces/http/routes/household.routes';
 import invitationRoutes from './interfaces/http/routes/invitation.routes';
 import itemRoutes from './interfaces/http/routes/item.routes';
 import budgetRoutes from './interfaces/http/routes/budget.routes';
+import currencyRoutes from './interfaces/http/routes/currency.routes';
 
 const app = express();
 app.use(express.json());
@@ -19,6 +20,7 @@ app.use('/api/v1/households', householdRoutes);
 app.use('/api/v1/invitations', invitationRoutes);
 app.use('/api/v1/households/:householdId/items', itemRoutes);
 app.use('/api/v1/households/:householdId/budget', budgetRoutes);
+app.use('/api/v1/currency', currencyRoutes);
 
 app.get('/', (_req, res) => {
   res.send('API de Nidify');


### PR DESCRIPTION
## Summary
- add exchange rate schema and repository with caching
- implement provider and use case for currency conversion
- expose `/api/v1/currency/convert` endpoint and related config

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ffb7698cc8326b95eb71ed8143f47