### PR TITLE
feat: add changelog support

### DIFF
--- a/Backend/src/application/use-cases/delete-item.usecase.ts
+++ b/Backend/src/application/use-cases/delete-item.usecase.ts
@@ -1,13 +1,31 @@
 import { Item } from '../../domain/models/item.model';
 import { ItemRepository } from '../../infrastructure/persistence/repositories/item.repository';
+import { DomainEventBus } from '../../domain/events/domain-event-bus.interface';
+import { ItemDeletedEvent } from '../../domain/events/item.events';
 
 export class DeleteItemUseCase {
-  constructor(private itemRepo: ItemRepository) {}
+  constructor(
+    private itemRepo: ItemRepository,
+    private eventBus: DomainEventBus,
+  ) {}
 
-  async execute(itemId: string): Promise<Item | null> {
+  async execute(
+    userId: string,
+    itemId: string,
+    userName?: string,
+  ): Promise<Item | null> {
     const item = await this.itemRepo.findById(itemId);
     if (!item) return null;
     await this.itemRepo.delete(itemId);
+    const event: ItemDeletedEvent = {
+      type: 'ItemDeleted',
+      occurredOn: new Date(),
+      householdId: item.householdId,
+      item,
+      userId,
+      ...(userName ? { userName } : {}),
+    };
+    await this.eventBus.publish(event);
     return item;
   }
 }

--- a/Backend/src/application/use-cases/list-changelog.usecase.ts
+++ b/Backend/src/application/use-cases/list-changelog.usecase.ts
@@ -1,0 +1,10 @@
+import { ChangelogEntry } from '../../domain/models/changelog-entry.model';
+import { ChangelogRepository } from '../../infrastructure/persistence/repositories/changelog.repository';
+
+export class ListChangelogUseCase {
+  constructor(private repo: ChangelogRepository) {}
+
+  async execute(householdId: string): Promise<ChangelogEntry[]> {
+    return this.repo.findByHousehold(householdId);
+  }
+}

--- a/Backend/src/domain/events/budget.events.ts
+++ b/Backend/src/domain/events/budget.events.ts
@@ -1,0 +1,12 @@
+import { DomainEvent } from './domain-event.interface';
+import { BudgetGoalType } from '../models/enums/budget-goal-type.enum';
+
+export interface BudgetGoalUpdatedEvent extends DomainEvent {
+  type: 'BudgetGoalUpdated';
+  householdId: string;
+  userId: string;
+  userName?: string;
+  goalType: BudgetGoalType;
+  previousAmount: number;
+  newAmount: number;
+}

--- a/Backend/src/domain/events/domain-event-bus.interface.ts
+++ b/Backend/src/domain/events/domain-event-bus.interface.ts
@@ -1,0 +1,9 @@
+import { DomainEvent } from './domain-event.interface';
+
+export interface DomainEventBus {
+  publish(event: DomainEvent): Promise<void>;
+  subscribe<T extends DomainEvent>(
+    type: string,
+    handler: (event: T) => Promise<void>,
+  ): void;
+}

--- a/Backend/src/domain/events/domain-event.interface.ts
+++ b/Backend/src/domain/events/domain-event.interface.ts
@@ -1,0 +1,4 @@
+export interface DomainEvent {
+  type: string;
+  occurredOn: Date;
+}

--- a/Backend/src/domain/events/item.events.ts
+++ b/Backend/src/domain/events/item.events.ts
@@ -1,0 +1,27 @@
+import { DomainEvent } from './domain-event.interface';
+import { Item } from '../models/item.model';
+
+export interface ItemCreatedEvent extends DomainEvent {
+  type: 'ItemCreated';
+  householdId: string;
+  item: Item;
+  userId: string;
+  userName?: string;
+}
+
+export interface ItemUpdatedEvent extends DomainEvent {
+  type: 'ItemUpdated';
+  householdId: string;
+  before: Item;
+  after: Item;
+  userId: string;
+  userName?: string;
+}
+
+export interface ItemDeletedEvent extends DomainEvent {
+  type: 'ItemDeleted';
+  householdId: string;
+  item: Item;
+  userId: string;
+  userName?: string;
+}

--- a/Backend/src/infrastructure/events/changelog.subscriber.ts
+++ b/Backend/src/infrastructure/events/changelog.subscriber.ts
@@ -1,0 +1,75 @@
+import { domainEventBus } from './domain-event-bus';
+import { ChangelogRepository } from '../persistence/repositories/changelog.repository';
+import { ChangelogEntityType } from '../../domain/models/enums/changelog-entity-type.enum';
+import { ChangelogChangeType } from '../../domain/models/enums/changelog-change-type.enum';
+import {
+  ItemCreatedEvent,
+  ItemUpdatedEvent,
+  ItemDeletedEvent,
+} from '../../domain/events/item.events';
+import { BudgetGoalUpdatedEvent } from '../../domain/events/budget.events';
+
+const repo = new ChangelogRepository();
+
+domainEventBus.subscribe<ItemCreatedEvent>('ItemCreated', async (event) => {
+  await repo.create({
+    householdId: event.householdId,
+    entityType: ChangelogEntityType.ITEM,
+    entityId: event.item.id,
+    changeType: ChangelogChangeType.CREATE,
+    description: `Item ${event.item.name} created`,
+    diff: { after: event.item },
+    userId: event.userId,
+    userName: event.userName ?? '',
+    timestamp: event.occurredOn,
+  });
+});
+
+domainEventBus.subscribe<ItemUpdatedEvent>('ItemUpdated', async (event) => {
+  await repo.create({
+    householdId: event.householdId,
+    entityType: ChangelogEntityType.ITEM,
+    entityId: event.after.id,
+    changeType: ChangelogChangeType.UPDATE,
+    description: `Item ${event.after.name} updated`,
+    diff: { before: event.before, after: event.after },
+    userId: event.userId,
+    userName: event.userName ?? '',
+    timestamp: event.occurredOn,
+  });
+});
+
+domainEventBus.subscribe<ItemDeletedEvent>('ItemDeleted', async (event) => {
+  await repo.create({
+    householdId: event.householdId,
+    entityType: ChangelogEntityType.ITEM,
+    entityId: event.item.id,
+    changeType: ChangelogChangeType.DELETE,
+    description: `Item ${event.item.name} deleted`,
+    diff: { before: event.item },
+    userId: event.userId,
+    userName: event.userName ?? '',
+    timestamp: event.occurredOn,
+  });
+});
+
+domainEventBus.subscribe<BudgetGoalUpdatedEvent>(
+  'BudgetGoalUpdated',
+  async (event) => {
+    await repo.create({
+      householdId: event.householdId,
+      entityType: ChangelogEntityType.BUDGET,
+      entityId: event.householdId,
+      changeType: ChangelogChangeType.UPDATE,
+      description: `Budget goal ${event.goalType} updated`,
+      diff: {
+        previousAmount: event.previousAmount,
+        newAmount: event.newAmount,
+        type: event.goalType,
+      },
+      userId: event.userId,
+      userName: event.userName ?? '',
+      timestamp: event.occurredOn,
+    });
+  },
+);

--- a/Backend/src/infrastructure/events/domain-event-bus.ts
+++ b/Backend/src/infrastructure/events/domain-event-bus.ts
@@ -1,0 +1,20 @@
+import { EventEmitter } from 'events';
+import { DomainEvent } from '../../domain/events/domain-event.interface';
+import { DomainEventBus } from '../../domain/events/domain-event-bus.interface';
+
+class InMemoryDomainEventBus implements DomainEventBus {
+  private emitter = new EventEmitter();
+
+  async publish(event: DomainEvent): Promise<void> {
+    this.emitter.emit(event.type, event);
+  }
+
+  subscribe<T extends DomainEvent>(
+    type: string,
+    handler: (event: T) => Promise<void>,
+  ): void {
+    this.emitter.on(type, handler);
+  }
+}
+
+export const domainEventBus = new InMemoryDomainEventBus();

--- a/Backend/src/infrastructure/persistence/models/changelog-entry.schema.ts
+++ b/Backend/src/infrastructure/persistence/models/changelog-entry.schema.ts
@@ -1,0 +1,32 @@
+import { Schema, model, Document } from 'mongoose';
+import { ChangelogEntry } from '../../../domain/models/changelog-entry.model';
+import { ChangelogEntityType } from '../../../domain/models/enums/changelog-entity-type.enum';
+import { ChangelogChangeType } from '../../../domain/models/enums/changelog-change-type.enum';
+
+interface ChangelogDocument extends Document, Omit<ChangelogEntry, 'id'> {}
+
+const ChangelogSchema = new Schema<ChangelogDocument>({
+  householdId: { type: String, required: true },
+  entityType: {
+    type: String,
+    enum: Object.values(ChangelogEntityType),
+    required: true,
+  },
+  entityId: { type: String, required: true },
+  changeType: {
+    type: String,
+    enum: Object.values(ChangelogChangeType),
+    required: true,
+  },
+  description: { type: String, required: true },
+  diff: { type: Schema.Types.Mixed },
+  userId: { type: String, required: true },
+  userName: { type: String, required: true },
+  timestamp: { type: Date, default: Date.now },
+  metadata: { type: Schema.Types.Mixed },
+});
+
+export const ChangelogModel = model<ChangelogDocument>(
+  'Changelog',
+  ChangelogSchema,
+);

--- a/Backend/src/infrastructure/persistence/repositories/changelog.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/changelog.repository.ts
@@ -1,0 +1,15 @@
+import { ChangelogEntry } from '../../../domain/models/changelog-entry.model';
+import { ChangelogModel } from '../models/changelog-entry.schema';
+
+export class ChangelogRepository {
+  async findByHousehold(householdId: string): Promise<ChangelogEntry[]> {
+    return (await ChangelogModel.find({ householdId })
+      .sort({ timestamp: -1 })
+      .lean()) as ChangelogEntry[];
+  }
+
+  async create(entry: Omit<ChangelogEntry, 'id'>): Promise<ChangelogEntry> {
+    const created = await ChangelogModel.create(entry);
+    return { id: created.id, ...created.toObject() } as ChangelogEntry;
+  }
+}

--- a/Backend/src/interfaces/http/controllers/changelog.controller.ts
+++ b/Backend/src/interfaces/http/controllers/changelog.controller.ts
@@ -1,0 +1,12 @@
+import { Request, Response } from 'express';
+import { ListChangelogUseCase } from '../../../application/use-cases/list-changelog.usecase';
+
+export class ChangelogController {
+  constructor(private listChangelog: ListChangelogUseCase) {}
+
+  list = async (req: Request, res: Response) => {
+    const { householdId } = req.params as { householdId: string };
+    const entries = await this.listChangelog.execute(householdId);
+    res.json({ entries });
+  };
+}

--- a/Backend/src/interfaces/http/controllers/item.controller.ts
+++ b/Backend/src/interfaces/http/controllers/item.controller.ts
@@ -47,7 +47,8 @@ export class ItemController {
 
   delete = async (req: Request, res: Response) => {
     const { itemId } = req.params as { itemId: string };
-    const item = await this.deleteItem.execute(itemId);
+    const userId = (req as AuthRequest).userId;
+    const item = await this.deleteItem.execute(userId, itemId);
     if (!item) {
       return res.status(404).json({ error: 'Item not found' });
     }

--- a/Backend/src/interfaces/http/routes/budget.routes.ts
+++ b/Backend/src/interfaces/http/routes/budget.routes.ts
@@ -7,6 +7,7 @@ import { GetBudgetSummaryUseCase } from '../../../application/use-cases/get-budg
 import { UpdateBudgetGoalUseCase } from '../../../application/use-cases/update-budget-goal.usecase';
 import { JwtService } from '../../../infrastructure/auth/jwt.service';
 import { authMiddleware } from '../../middleware/auth.middleware';
+import { domainEventBus } from '../../../infrastructure/events/domain-event-bus';
 
 const router = Router({ mergeParams: true });
 
@@ -14,7 +15,11 @@ const householdRepo = new HouseholdRepository();
 const itemRepo = new ItemRepository();
 const changeRepo = new BudgetChangeRepository();
 const getSummary = new GetBudgetSummaryUseCase(householdRepo, itemRepo);
-const updateGoal = new UpdateBudgetGoalUseCase(householdRepo, changeRepo);
+const updateGoal = new UpdateBudgetGoalUseCase(
+  householdRepo,
+  changeRepo,
+  domainEventBus,
+);
 const controller = new BudgetController(getSummary, updateGoal);
 
 const jwtService = new JwtService();

--- a/Backend/src/interfaces/http/routes/changelog.routes.ts
+++ b/Backend/src/interfaces/http/routes/changelog.routes.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import { ChangelogRepository } from '../../../infrastructure/persistence/repositories/changelog.repository';
+import { JwtService } from '../../../infrastructure/auth/jwt.service';
+import { authMiddleware } from '../../middleware/auth.middleware';
+import { ListChangelogUseCase } from '../../../application/use-cases/list-changelog.usecase';
+import { ChangelogController } from '../controllers/changelog.controller';
+
+const router = Router({ mergeParams: true });
+
+const changelogRepo = new ChangelogRepository();
+const listChangelog = new ListChangelogUseCase(changelogRepo);
+const controller = new ChangelogController(listChangelog);
+
+const jwtService = new JwtService();
+
+router.get('/', authMiddleware(jwtService), controller.list);
+
+export default router;

--- a/Backend/src/interfaces/http/routes/item.routes.ts
+++ b/Backend/src/interfaces/http/routes/item.routes.ts
@@ -6,6 +6,7 @@ import { CreateItemUseCase } from '../../../application/use-cases/create-item.us
 import { ListItemsUseCase } from '../../../application/use-cases/list-items.usecase';
 import { UpdateItemUseCase } from '../../../application/use-cases/update-item.usecase';
 import { DeleteItemUseCase } from '../../../application/use-cases/delete-item.usecase';
+import { domainEventBus } from '../../../infrastructure/events/domain-event-bus';
 import { ItemController } from '../controllers/item.controller';
 
 const router = Router({ mergeParams: true });
@@ -13,10 +14,10 @@ const router = Router({ mergeParams: true });
 const itemRepo = new ItemRepository();
 const jwtService = new JwtService();
 
-const createItem = new CreateItemUseCase(itemRepo);
+const createItem = new CreateItemUseCase(itemRepo, domainEventBus);
 const listItems = new ListItemsUseCase(itemRepo);
-const updateItem = new UpdateItemUseCase(itemRepo);
-const deleteItem = new DeleteItemUseCase(itemRepo);
+const updateItem = new UpdateItemUseCase(itemRepo, domainEventBus);
+const deleteItem = new DeleteItemUseCase(itemRepo, domainEventBus);
 
 const controller = new ItemController(
   createItem,

--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -8,7 +8,9 @@ import invitationRoutes from './interfaces/http/routes/invitation.routes';
 import itemRoutes from './interfaces/http/routes/item.routes';
 import budgetRoutes from './interfaces/http/routes/budget.routes';
 import currencyRoutes from './interfaces/http/routes/currency.routes';
+import changelogRoutes from './interfaces/http/routes/changelog.routes';
 import { initSocket } from './infrastructure/websocket/socket.service';
+import './infrastructure/events/changelog.subscriber';
 
 const app = express();
 app.use(express.json());
@@ -25,6 +27,7 @@ app.use('/api/v1/households', householdRoutes);
 app.use('/api/v1/invitations', invitationRoutes);
 app.use('/api/v1/households/:householdId/items', itemRoutes);
 app.use('/api/v1/households/:householdId/budget', budgetRoutes);
+app.use('/api/v1/households/:householdId/changelog', changelogRoutes);
 app.use('/api/v1/currency', currencyRoutes);
 
 app.get('/', (_req, res) => {


### PR DESCRIPTION
## Summary
- replace direct changelog writes with domain events and subscriber
- emit changelog events from item and budget use cases

## Testing
- `npm ci`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689002717f2c832688b2a2cc627e3686