### PR TITLE
Add notification preferences and budget alerts

### DIFF
--- a/Backend/src/application/use-cases/get-notification-preferences.usecase.ts
+++ b/Backend/src/application/use-cases/get-notification-preferences.usecase.ts
@@ -1,0 +1,21 @@
+import { NotificationPreferences } from '../../domain/models/notification-preferences.model';
+import { NotificationPreferencesRepository } from '../../infrastructure/persistence/repositories/notification-preferences.repository';
+
+export class GetNotificationPreferencesUseCase {
+  constructor(private repo: NotificationPreferencesRepository) {}
+
+  async execute(
+    userId: string,
+    householdId: string,
+  ): Promise<NotificationPreferences> {
+    const prefs = await this.repo.findByUserAndHousehold(userId, householdId);
+    if (prefs) return prefs;
+    return {
+      id: '',
+      userId,
+      householdId,
+      alerts: { budgetExceeded: true },
+      mediums: ['in_app'],
+    };
+  }
+}

--- a/Backend/src/application/use-cases/list-alerts.usecase.ts
+++ b/Backend/src/application/use-cases/list-alerts.usecase.ts
@@ -1,0 +1,10 @@
+import { Alert } from '../../domain/models/alert.model';
+import { AlertRepository } from '../../infrastructure/persistence/repositories/alert.repository';
+
+export class ListAlertsUseCase {
+  constructor(private repo: AlertRepository) {}
+
+  async execute(userId: string, householdId: string): Promise<Alert[]> {
+    return await this.repo.findByUser(userId, householdId);
+  }
+}

--- a/Backend/src/application/use-cases/mark-alert-read.usecase.ts
+++ b/Backend/src/application/use-cases/mark-alert-read.usecase.ts
@@ -1,0 +1,10 @@
+import { Alert } from '../../domain/models/alert.model';
+import { AlertRepository } from '../../infrastructure/persistence/repositories/alert.repository';
+
+export class MarkAlertReadUseCase {
+  constructor(private repo: AlertRepository) {}
+
+  async execute(id: string, userId: string): Promise<Alert | null> {
+    return await this.repo.markRead(id, userId);
+  }
+}

--- a/Backend/src/application/use-cases/update-notification-preferences.usecase.ts
+++ b/Backend/src/application/use-cases/update-notification-preferences.usecase.ts
@@ -1,0 +1,24 @@
+import { NotificationPreferences } from '../../domain/models/notification-preferences.model';
+import { NotificationPreferencesRepository } from '../../infrastructure/persistence/repositories/notification-preferences.repository';
+
+export interface UpdateNotificationPreferencesPayload {
+  alerts?: NotificationPreferences['alerts'];
+  mediums?: string[];
+  thresholds?: NotificationPreferences['thresholds'];
+}
+
+export class UpdateNotificationPreferencesUseCase {
+  constructor(private repo: NotificationPreferencesRepository) {}
+
+  async execute(
+    userId: string,
+    householdId: string,
+    payload: UpdateNotificationPreferencesPayload,
+  ): Promise<NotificationPreferences> {
+    return await this.repo.upsert(
+      userId,
+      householdId,
+      payload as Partial<NotificationPreferences>,
+    );
+  }
+}

--- a/Backend/src/domain/models/alert.model.ts
+++ b/Backend/src/domain/models/alert.model.ts
@@ -1,0 +1,19 @@
+import { AlertType } from './enums/alert-type.enum';
+
+/** In-app alert for users */
+export interface Alert {
+  /** Unique identifier */
+  id: string;
+  /** User that receives the alert */
+  userId: string;
+  /** Related household if applicable */
+  householdId?: string;
+  /** Alert type */
+  type: AlertType;
+  /** Human readable message */
+  message: string;
+  /** Creation timestamp */
+  createdAt: Date;
+  /** Whether the alert has been read */
+  read: boolean;
+}

--- a/Backend/src/domain/models/enums/alert-type.enum.ts
+++ b/Backend/src/domain/models/enums/alert-type.enum.ts
@@ -1,0 +1,4 @@
+export enum AlertType {
+  BUDGET_THRESHOLD = 'budget_threshold',
+  MONTHLY_SERVICE_REMINDER = 'monthly_service_reminder',
+}

--- a/Backend/src/infrastructure/events/alerts.subscriber.ts
+++ b/Backend/src/infrastructure/events/alerts.subscriber.ts
@@ -1,0 +1,102 @@
+import { domainEventBus } from './domain-event-bus';
+import { HouseholdRepository } from '../persistence/repositories/household.repository';
+import { ItemRepository } from '../persistence/repositories/item.repository';
+import { NotificationPreferencesRepository } from '../persistence/repositories/notification-preferences.repository';
+import { AlertRepository } from '../persistence/repositories/alert.repository';
+import { UserRepository } from '../persistence/repositories/user.repository';
+import { GetBudgetSummaryUseCase } from '../../application/use-cases/get-budget-summary.usecase';
+import { AlertType } from '../../domain/models/enums/alert-type.enum';
+import {
+  ItemCreatedEvent,
+  ItemUpdatedEvent,
+  ItemDeletedEvent,
+} from '../../domain/events/item.events';
+import { BudgetGoalUpdatedEvent } from '../../domain/events/budget.events';
+import { notifyHousehold } from '../websocket/socket.service';
+import { EmailService } from '../notifications/email.service';
+
+const householdRepo = new HouseholdRepository();
+const itemRepo = new ItemRepository();
+const prefsRepo = new NotificationPreferencesRepository();
+const alertRepo = new AlertRepository();
+const userRepo = new UserRepository();
+const emailService = new EmailService();
+const getSummary = new GetBudgetSummaryUseCase(householdRepo, itemRepo);
+
+const checkBudgetAlerts = async (householdId: string) => {
+  const household = await householdRepo.findById(householdId);
+  if (!household) return;
+  const summary = await getSummary.execute(householdId);
+  if (!summary) return;
+  const initialGoal = household.initialBudgetGoal?.amount;
+  const monthlyGoal = household.monthlyBudgetGoal;
+  const initialUsage =
+    initialGoal && initialGoal > 0
+      ? summary.initialTotal / initialGoal
+      : undefined;
+  const monthlyUsage =
+    monthlyGoal && monthlyGoal > 0
+      ? summary.monthlyTotal / monthlyGoal
+      : undefined;
+  const prefs = await prefsRepo.findByHousehold(householdId);
+  for (const pref of prefs) {
+    if (!pref.alerts?.budgetExceeded) continue;
+    const threshold =
+      pref.thresholds?.budgetUsage ??
+      household.alertsConfig?.budgetUsageThreshold ??
+      1;
+    if (initialUsage !== undefined && initialUsage >= threshold) {
+      const alert = await alertRepo.create({
+        userId: pref.userId,
+        householdId,
+        type: AlertType.BUDGET_THRESHOLD,
+        message: `Initial budget used ${(initialUsage * 100).toFixed(0)}%`,
+        createdAt: new Date(),
+        read: false,
+      });
+      notifyHousehold(householdId, 'alert:new', alert);
+      if (pref.mediums.includes('email')) {
+        const user = await userRepo.findById(pref.userId);
+        if (user?.email) {
+          await emailService.sendAlert(user.email, alert.message);
+        }
+      }
+    }
+    if (monthlyUsage !== undefined && monthlyUsage >= threshold) {
+      const alert = await alertRepo.create({
+        userId: pref.userId,
+        householdId,
+        type: AlertType.BUDGET_THRESHOLD,
+        message: `Monthly budget used ${(monthlyUsage * 100).toFixed(0)}%`,
+        createdAt: new Date(),
+        read: false,
+      });
+      notifyHousehold(householdId, 'alert:new', alert);
+      if (pref.mediums.includes('email')) {
+        const user = await userRepo.findById(pref.userId);
+        if (user?.email) {
+          await emailService.sendAlert(user.email, alert.message);
+        }
+      }
+    }
+  }
+};
+
+domainEventBus.subscribe<ItemCreatedEvent>('ItemCreated', async (event) => {
+  await checkBudgetAlerts(event.householdId);
+});
+
+domainEventBus.subscribe<ItemUpdatedEvent>('ItemUpdated', async (event) => {
+  await checkBudgetAlerts(event.householdId);
+});
+
+domainEventBus.subscribe<ItemDeletedEvent>('ItemDeleted', async (event) => {
+  await checkBudgetAlerts(event.householdId);
+});
+
+domainEventBus.subscribe<BudgetGoalUpdatedEvent>(
+  'BudgetGoalUpdated',
+  async (event) => {
+    await checkBudgetAlerts(event.householdId);
+  },
+);

--- a/Backend/src/infrastructure/notifications/email.service.ts
+++ b/Backend/src/infrastructure/notifications/email.service.ts
@@ -1,6 +1,11 @@
 export class EmailService {
   async sendInvitation(email: string, token: string): Promise<void> {
-    // Placeholder implementation for sending emails
+    // Placeholder implementation for sending invitation emails
     console.log(`Sending invitation to ${email} with token ${token}`);
+  }
+
+  async sendAlert(email: string, message: string): Promise<void> {
+    // Placeholder implementation for sending alert emails
+    console.log(`Sending alert to ${email}: ${message}`);
   }
 }

--- a/Backend/src/infrastructure/persistence/models/alert.schema.ts
+++ b/Backend/src/infrastructure/persistence/models/alert.schema.ts
@@ -1,0 +1,16 @@
+import { Schema, model, Document } from 'mongoose';
+import { Alert } from '../../../domain/models/alert.model';
+import { AlertType } from '../../../domain/models/enums/alert-type.enum';
+
+interface AlertDocument extends Document, Omit<Alert, 'id'> {}
+
+const AlertSchema = new Schema<AlertDocument>({
+  userId: { type: String, required: true },
+  householdId: { type: String },
+  type: { type: String, enum: Object.values(AlertType), required: true },
+  message: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+  read: { type: Boolean, default: false },
+});
+
+export const AlertModel = model<AlertDocument>('Alert', AlertSchema);

--- a/Backend/src/infrastructure/persistence/models/notification-preferences.schema.ts
+++ b/Backend/src/infrastructure/persistence/models/notification-preferences.schema.ts
@@ -1,0 +1,30 @@
+import { Schema, model, Document } from 'mongoose';
+import { NotificationPreferences } from '../../../domain/models/notification-preferences.model';
+
+interface NotificationPreferencesDocument
+  extends Document,
+    Omit<NotificationPreferences, 'id'> {}
+
+const AlertsSchema = new Schema({
+  budgetExceeded: { type: Boolean, default: false },
+  monthlyServiceReminder: { type: Boolean, default: false },
+});
+
+const ThresholdsSchema = new Schema({
+  budgetUsage: { type: Number },
+});
+
+const NotificationPreferencesSchema =
+  new Schema<NotificationPreferencesDocument>({
+    userId: { type: String, required: true },
+    householdId: { type: String },
+    alerts: { type: AlertsSchema, default: {} },
+    mediums: { type: [String], default: ['in_app'] },
+    thresholds: { type: ThresholdsSchema },
+  });
+
+export const NotificationPreferencesModel =
+  model<NotificationPreferencesDocument>(
+    'NotificationPreferences',
+    NotificationPreferencesSchema,
+  );

--- a/Backend/src/infrastructure/persistence/repositories/alert.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/alert.repository.ts
@@ -1,0 +1,25 @@
+import { Alert } from '../../../domain/models/alert.model';
+import { AlertModel } from '../models/alert.schema';
+
+export class AlertRepository {
+  async create(alert: Omit<Alert, 'id'>): Promise<Alert> {
+    const created = await AlertModel.create(alert);
+    return { id: created.id, ...created.toObject() } as unknown as Alert;
+  }
+
+  async findByUser(userId: string, householdId?: string): Promise<Alert[]> {
+    const query: Record<string, unknown> = { userId };
+    if (householdId) query.householdId = householdId;
+    return (await AlertModel.find(query)
+      .sort({ createdAt: -1 })
+      .lean()) as Alert[];
+  }
+
+  async markRead(id: string, userId: string): Promise<Alert | null> {
+    return (await AlertModel.findOneAndUpdate(
+      { _id: id, userId },
+      { read: true },
+      { new: true },
+    ).lean()) as Alert | null;
+  }
+}

--- a/Backend/src/infrastructure/persistence/repositories/notification-preferences.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/notification-preferences.repository.ts
@@ -1,0 +1,35 @@
+import { NotificationPreferences } from '../../../domain/models/notification-preferences.model';
+import { NotificationPreferencesModel } from '../models/notification-preferences.schema';
+
+export class NotificationPreferencesRepository {
+  async findByUserAndHousehold(
+    userId: string,
+    householdId: string,
+  ): Promise<NotificationPreferences | null> {
+    return (await NotificationPreferencesModel.findOne({
+      userId,
+      householdId,
+    }).lean()) as NotificationPreferences | null;
+  }
+
+  async findByHousehold(
+    householdId: string,
+  ): Promise<NotificationPreferences[]> {
+    return (await NotificationPreferencesModel.find({
+      householdId,
+    }).lean()) as NotificationPreferences[];
+  }
+
+  async upsert(
+    userId: string,
+    householdId: string,
+    prefs: Partial<NotificationPreferences>,
+  ): Promise<NotificationPreferences> {
+    const updated = await NotificationPreferencesModel.findOneAndUpdate(
+      { userId, householdId },
+      { $set: prefs },
+      { new: true, upsert: true },
+    ).lean();
+    return updated as NotificationPreferences;
+  }
+}

--- a/Backend/src/interfaces/http/controllers/alert.controller.ts
+++ b/Backend/src/interfaces/http/controllers/alert.controller.ts
@@ -1,0 +1,31 @@
+import { Request, Response } from 'express';
+import { ListAlertsUseCase } from '../../../application/use-cases/list-alerts.usecase';
+import { MarkAlertReadUseCase } from '../../../application/use-cases/mark-alert-read.usecase';
+
+interface AuthRequest extends Request {
+  userId: string;
+}
+
+export class AlertController {
+  constructor(
+    private listAlertsUseCase: ListAlertsUseCase,
+    private markAlertReadUseCase: MarkAlertReadUseCase,
+  ) {}
+
+  list = async (req: Request, res: Response) => {
+    const { householdId } = req.params as { householdId: string };
+    const userId = (req as AuthRequest).userId;
+    const alerts = await this.listAlertsUseCase.execute(userId, householdId);
+    res.json({ alerts });
+  };
+
+  markRead = async (req: Request, res: Response) => {
+    const { alertId } = req.params as { alertId: string };
+    const userId = (req as AuthRequest).userId;
+    const alert = await this.markAlertReadUseCase.execute(alertId, userId);
+    if (!alert) {
+      return res.status(404).json({ error: 'Alert not found' });
+    }
+    res.json({ alert });
+  };
+}

--- a/Backend/src/interfaces/http/controllers/notification-preferences.controller.ts
+++ b/Backend/src/interfaces/http/controllers/notification-preferences.controller.ts
@@ -1,0 +1,30 @@
+import { Request, Response } from 'express';
+import { GetNotificationPreferencesUseCase } from '../../../application/use-cases/get-notification-preferences.usecase';
+import { UpdateNotificationPreferencesUseCase } from '../../../application/use-cases/update-notification-preferences.usecase';
+import { NotificationPreferencesDto } from '../dto/notification-preferences.dto';
+
+interface AuthRequest extends Request {
+  userId: string;
+}
+
+export class NotificationPreferencesController {
+  constructor(
+    private getPrefs: GetNotificationPreferencesUseCase,
+    private updatePrefs: UpdateNotificationPreferencesUseCase,
+  ) {}
+
+  get = async (req: Request, res: Response) => {
+    const { householdId } = req.params as { householdId: string };
+    const userId = (req as AuthRequest).userId;
+    const prefs = await this.getPrefs.execute(userId, householdId);
+    res.json({ preferences: prefs });
+  };
+
+  update = async (req: Request, res: Response) => {
+    const { householdId } = req.params as { householdId: string };
+    const userId = (req as AuthRequest).userId;
+    const payload = req.body as NotificationPreferencesDto;
+    await this.updatePrefs.execute(userId, householdId, payload);
+    res.status(204).send();
+  };
+}

--- a/Backend/src/interfaces/http/dto/notification-preferences.dto.ts
+++ b/Backend/src/interfaces/http/dto/notification-preferences.dto.ts
@@ -1,0 +1,10 @@
+export interface NotificationPreferencesDto {
+  alerts?: {
+    budgetExceeded?: boolean;
+    monthlyServiceReminder?: boolean;
+  };
+  mediums?: string[];
+  thresholds?: {
+    budgetUsage?: number;
+  };
+}

--- a/Backend/src/interfaces/http/routes/alert.routes.ts
+++ b/Backend/src/interfaces/http/routes/alert.routes.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import { AlertController } from '../controllers/alert.controller';
+import { AlertRepository } from '../../../infrastructure/persistence/repositories/alert.repository';
+import { ListAlertsUseCase } from '../../../application/use-cases/list-alerts.usecase';
+import { MarkAlertReadUseCase } from '../../../application/use-cases/mark-alert-read.usecase';
+import { JwtService } from '../../../infrastructure/auth/jwt.service';
+import { authMiddleware } from '../../middleware/auth.middleware';
+
+const router = Router({ mergeParams: true });
+
+const repo = new AlertRepository();
+const listAlerts = new ListAlertsUseCase(repo);
+const markRead = new MarkAlertReadUseCase(repo);
+const controller = new AlertController(listAlerts, markRead);
+
+const jwtService = new JwtService();
+
+router.get('/', authMiddleware(jwtService), controller.list);
+router.put('/:alertId/read', authMiddleware(jwtService), controller.markRead);
+
+export default router;

--- a/Backend/src/interfaces/http/routes/notification-preferences.routes.ts
+++ b/Backend/src/interfaces/http/routes/notification-preferences.routes.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import { NotificationPreferencesController } from '../controllers/notification-preferences.controller';
+import { NotificationPreferencesRepository } from '../../../infrastructure/persistence/repositories/notification-preferences.repository';
+import { GetNotificationPreferencesUseCase } from '../../../application/use-cases/get-notification-preferences.usecase';
+import { UpdateNotificationPreferencesUseCase } from '../../../application/use-cases/update-notification-preferences.usecase';
+import { JwtService } from '../../../infrastructure/auth/jwt.service';
+import { authMiddleware } from '../../middleware/auth.middleware';
+
+const router = Router({ mergeParams: true });
+
+const repo = new NotificationPreferencesRepository();
+const getPrefs = new GetNotificationPreferencesUseCase(repo);
+const updatePrefs = new UpdateNotificationPreferencesUseCase(repo);
+const controller = new NotificationPreferencesController(getPrefs, updatePrefs);
+
+const jwtService = new JwtService();
+
+router.get('/', authMiddleware(jwtService), controller.get);
+router.put('/', authMiddleware(jwtService), controller.update);
+
+export default router;

--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -9,8 +9,11 @@ import itemRoutes from './interfaces/http/routes/item.routes';
 import budgetRoutes from './interfaces/http/routes/budget.routes';
 import currencyRoutes from './interfaces/http/routes/currency.routes';
 import changelogRoutes from './interfaces/http/routes/changelog.routes';
+import preferencesRoutes from './interfaces/http/routes/notification-preferences.routes';
+import alertRoutes from './interfaces/http/routes/alert.routes';
 import { initSocket } from './infrastructure/websocket/socket.service';
 import './infrastructure/events/changelog.subscriber';
+import './infrastructure/events/alerts.subscriber';
 
 const app = express();
 app.use(express.json());
@@ -28,6 +31,8 @@ app.use('/api/v1/invitations', invitationRoutes);
 app.use('/api/v1/households/:householdId/items', itemRoutes);
 app.use('/api/v1/households/:householdId/budget', budgetRoutes);
 app.use('/api/v1/households/:householdId/changelog', changelogRoutes);
+app.use('/api/v1/households/:householdId/preferences', preferencesRoutes);
+app.use('/api/v1/households/:householdId/alerts', alertRoutes);
 app.use('/api/v1/currency', currencyRoutes);
 
 app.get('/', (_req, res) => {


### PR DESCRIPTION
## Summary
- add alert models, repositories, controllers and routes for in-app notifications
- store user notification preferences and generate budget threshold alerts from domain events
- wire up alert and preference endpoints with email service and server routes

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689010da01bc83268a9a0ba0444fcac0