### PR TITLE
Validate and calculate payment split

### DIFF
--- a/Backend/src/application/use-cases/create-item.usecase.ts
+++ b/Backend/src/application/use-cases/create-item.usecase.ts
@@ -4,6 +4,7 @@ import { ItemPriority } from '../../domain/models/enums/item-priority.enum';
 import { ItemStatus } from '../../domain/models/enums/item-status.enum';
 import { ItemType } from '../../domain/models/enums/item-type.enum';
 import { PaymentSplit } from '../../domain/models/payment-split.model';
+import { calculatePaymentSplit } from '../../domain/services/payment-split.service';
 import { DomainEventBus } from '../../domain/events/domain-event-bus.interface';
 import { ItemCreatedEvent } from '../../domain/events/item.events';
 
@@ -38,9 +39,13 @@ export class CreateItemUseCase {
     payload: CreateItemPayload,
   ): Promise<Item> {
     const now = new Date();
+    const paymentSplit = payload.paymentSplit
+      ? calculatePaymentSplit(payload.price, payload.paymentSplit)
+      : undefined;
     const item: Omit<Item, 'id'> = {
       householdId,
       ...payload,
+      ...(paymentSplit ? { paymentSplit } : {}),
       createdAt: now,
       updatedAt: now,
       lastModifiedBy: userId,

--- a/Backend/src/application/use-cases/get-budget-summary.usecase.ts
+++ b/Backend/src/application/use-cases/get-budget-summary.usecase.ts
@@ -40,9 +40,9 @@ export class GetBudgetSummaryUseCase {
           }
           const totals = memberTotalsMap[assignment.userId]!;
           if (item.type === ItemType.ONE_TIME) {
-            totals.initial += assignment.calculatedAmount;
+            totals.initial += assignment.calculatedAmount ?? 0;
           } else if (item.type === ItemType.RECURRING) {
-            totals.monthly += assignment.calculatedAmount;
+            totals.monthly += assignment.calculatedAmount ?? 0;
           }
         }
       }

--- a/Backend/src/application/use-cases/update-item.usecase.ts
+++ b/Backend/src/application/use-cases/update-item.usecase.ts
@@ -4,6 +4,7 @@ import { ItemPriority } from '../../domain/models/enums/item-priority.enum';
 import { ItemStatus } from '../../domain/models/enums/item-status.enum';
 import { ItemType } from '../../domain/models/enums/item-type.enum';
 import { PaymentSplit } from '../../domain/models/payment-split.model';
+import { calculatePaymentSplit } from '../../domain/services/payment-split.service';
 import { DomainEventBus } from '../../domain/events/domain-event-bus.interface';
 import { ItemUpdatedEvent } from '../../domain/events/item.events';
 
@@ -39,8 +40,11 @@ export class UpdateItemUseCase {
   ): Promise<Item | null> {
     const before = await this.itemRepo.findById(itemId);
     if (!before) return null;
+    const price = payload.price ?? before.price;
+    const split = payload.paymentSplit ?? before.paymentSplit;
     const update: Partial<Item> = {
       ...payload,
+      ...(split ? { paymentSplit: calculatePaymentSplit(price, split) } : {}),
       lastModifiedBy: userId,
       updatedAt: new Date(),
     };

--- a/Backend/src/domain/errors/invalid-payment-split.error.ts
+++ b/Backend/src/domain/errors/invalid-payment-split.error.ts
@@ -1,0 +1,6 @@
+export class InvalidPaymentSplitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidPaymentSplitError';
+  }
+}

--- a/Backend/src/domain/models/payment-split.model.ts
+++ b/Backend/src/domain/models/payment-split.model.ts
@@ -6,7 +6,7 @@ export interface PaymentAssignment {
   /** Explicit amount share */
   amount?: number;
   /** Denormalized calculated amount for quick reads */
-  calculatedAmount: number;
+  calculatedAmount?: number;
   /** Optional label for the contribution */
   label?: string;
 }

--- a/Backend/src/domain/services/payment-split.service.ts
+++ b/Backend/src/domain/services/payment-split.service.ts
@@ -1,0 +1,58 @@
+import { PaymentSplit } from '../models/payment-split.model';
+import { InvalidPaymentSplitError } from '../errors/invalid-payment-split.error';
+
+/**
+ * Validates a payment split and calculates per-assignment amounts.
+ * Accepts either percentage-based or amount-based assignments, but not both.
+ *
+ * @param price Base item price
+ * @param split Payment split definition
+ * @throws {InvalidPaymentSplitError} if validation fails
+ */
+export function calculatePaymentSplit(
+  price: number,
+  split: PaymentSplit,
+): PaymentSplit {
+  const assignments = split.assignments;
+  if (!assignments.length) return { assignments: [] };
+
+  const usesPercentage = assignments.every(
+    (a) => a.percentage !== undefined && a.amount === undefined,
+  );
+  const usesAmount = assignments.every(
+    (a) => a.amount !== undefined && a.percentage === undefined,
+  );
+
+  if (!usesPercentage && !usesAmount) {
+    throw new InvalidPaymentSplitError(
+      'Assignments must consistently use percentage or amount',
+    );
+  }
+
+  if (usesPercentage) {
+    const totalPercent = assignments.reduce(
+      (sum, a) => sum + (a.percentage ?? 0),
+      0,
+    );
+    if (Math.abs(totalPercent - 100) > 1e-6) {
+      throw new InvalidPaymentSplitError('Percentages must total 100');
+    }
+    return {
+      assignments: assignments.map((a) => ({
+        ...a,
+        calculatedAmount: +(price * ((a.percentage ?? 0) / 100)).toFixed(2),
+      })),
+    };
+  }
+
+  const totalAmount = assignments.reduce((sum, a) => sum + (a.amount ?? 0), 0);
+  if (Math.abs(totalAmount - price) > 0.01) {
+    throw new InvalidPaymentSplitError('Amounts must total item price');
+  }
+  return {
+    assignments: assignments.map((a) => ({
+      ...a,
+      calculatedAmount: a.amount ?? 0,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary
- add InvalidPaymentSplitError and service to validate and compute payment splits
- use the service when creating or updating items
- handle optional calculated amounts in budget summary

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68901a9f947c8326be039a13c667ac10