### PR TITLE
Add schema-based request validation

### DIFF
--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -15,7 +15,8 @@
         "google-auth-library": "^10.2.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.17.0",
-        "socket.io": "^4.7.5"
+        "socket.io": "^4.7.5",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/dotenv": "^6.1.1",
@@ -4972,6 +4973,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -26,7 +26,8 @@
     "google-auth-library": "^10.2.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.17.0",
-    "socket.io": "^4.7.5"
+    "socket.io": "^4.7.5",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/dotenv": "^6.1.1",

--- a/Backend/src/interfaces/http/controllers/budget.controller.ts
+++ b/Backend/src/interfaces/http/controllers/budget.controller.ts
@@ -36,7 +36,7 @@ export class BudgetController {
     const payload = req.body as UpdateBudgetRequestDto;
     const updatePayload: UpdateBudgetGoalPayload = { amount: payload.amount };
     if (payload.targetDate) {
-      updatePayload.targetDate = new Date(payload.targetDate);
+      updatePayload.targetDate = payload.targetDate;
     }
     if (payload.reason) {
       updatePayload.reason = payload.reason;

--- a/Backend/src/interfaces/http/controllers/currency.controller.ts
+++ b/Backend/src/interfaces/http/controllers/currency.controller.ts
@@ -3,20 +3,17 @@ import {
   ConvertCurrencyUseCase,
   ConvertCurrencyPayload,
 } from '../../../application/use-cases/convert-currency.usecase';
+import { ConvertCurrencyRequestDto } from '../dto/currency.dto';
 
 export class CurrencyController {
   constructor(private convertCurrency: ConvertCurrencyUseCase) {}
 
   convert = async (req: Request, res: Response) => {
-    const { from, to, amount } = req.query as unknown as {
-      from: string;
-      to: string;
-      amount: string;
-    };
+    const { from, to, amount } = req.query as unknown as ConvertCurrencyRequestDto;
     const payload: ConvertCurrencyPayload = {
       from: from.toUpperCase(),
       to: to.toUpperCase(),
-      amount: Number(amount),
+      amount,
     };
     const conversion = await this.convertCurrency.execute(payload);
     res.json({ conversion });

--- a/Backend/src/interfaces/http/controllers/item.controller.ts
+++ b/Backend/src/interfaces/http/controllers/item.controller.ts
@@ -1,7 +1,13 @@
 import { Request, Response } from 'express';
-import { CreateItemUseCase } from '../../../application/use-cases/create-item.usecase';
+import {
+  CreateItemUseCase,
+  CreateItemPayload,
+} from '../../../application/use-cases/create-item.usecase';
 import { ListItemsUseCase } from '../../../application/use-cases/list-items.usecase';
-import { UpdateItemUseCase } from '../../../application/use-cases/update-item.usecase';
+import {
+  UpdateItemUseCase,
+  UpdateItemPayload,
+} from '../../../application/use-cases/update-item.usecase';
 import { DeleteItemUseCase } from '../../../application/use-cases/delete-item.usecase';
 import { CreateItemRequestDto, UpdateItemRequestDto } from '../dto/item.dto';
 import { notifyHousehold } from '../../../infrastructure/websocket/socket.service';
@@ -28,7 +34,11 @@ export class ItemController {
     const { householdId } = req.params as { householdId: string };
     const userId = (req as AuthRequest).userId;
     const payload = req.body as CreateItemRequestDto;
-    const item = await this.createItem.execute(userId, householdId, payload);
+    const item = await this.createItem.execute(
+      userId,
+      householdId,
+      payload as CreateItemPayload,
+    );
     notifyHousehold(householdId, 'item:created', item);
     res.status(201).json({ item });
   };
@@ -37,7 +47,11 @@ export class ItemController {
     const { itemId } = req.params as { itemId: string };
     const userId = (req as AuthRequest).userId;
     const payload = req.body as UpdateItemRequestDto;
-    const item = await this.updateItem.execute(userId, itemId, payload);
+    const item = await this.updateItem.execute(
+      userId,
+      itemId,
+      payload as UpdateItemPayload,
+    );
     if (!item) {
       return res.status(404).json({ error: 'Item not found' });
     }

--- a/Backend/src/interfaces/http/controllers/notification-preferences.controller.ts
+++ b/Backend/src/interfaces/http/controllers/notification-preferences.controller.ts
@@ -1,6 +1,9 @@
 import { Request, Response } from 'express';
 import { GetNotificationPreferencesUseCase } from '../../../application/use-cases/get-notification-preferences.usecase';
-import { UpdateNotificationPreferencesUseCase } from '../../../application/use-cases/update-notification-preferences.usecase';
+import {
+  UpdateNotificationPreferencesUseCase,
+  UpdateNotificationPreferencesPayload,
+} from '../../../application/use-cases/update-notification-preferences.usecase';
 import { NotificationPreferencesDto } from '../dto/notification-preferences.dto';
 
 interface AuthRequest extends Request {
@@ -24,7 +27,11 @@ export class NotificationPreferencesController {
     const { householdId } = req.params as { householdId: string };
     const userId = (req as AuthRequest).userId;
     const payload = req.body as NotificationPreferencesDto;
-    await this.updatePrefs.execute(userId, householdId, payload);
+    await this.updatePrefs.execute(
+      userId,
+      householdId,
+      payload as UpdateNotificationPreferencesPayload,
+    );
     res.status(204).send();
   };
 }

--- a/Backend/src/interfaces/http/dto/auth.dto.ts
+++ b/Backend/src/interfaces/http/dto/auth.dto.ts
@@ -1,14 +1,19 @@
-export interface RegisterRequestDto {
-  fullName: string;
-  email: string;
-  password: string;
-}
+import { z } from 'zod';
 
-export interface LoginRequestDto {
-  email: string;
-  password: string;
-}
+export const registerSchema = z.object({
+  fullName: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+export type RegisterRequestDto = z.infer<typeof registerSchema>;
 
-export interface GoogleRequestDto {
-  idToken: string;
-}
+export const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+export type LoginRequestDto = z.infer<typeof loginSchema>;
+
+export const googleSchema = z.object({
+  idToken: z.string().min(1),
+});
+export type GoogleRequestDto = z.infer<typeof googleSchema>;

--- a/Backend/src/interfaces/http/dto/budget.dto.ts
+++ b/Backend/src/interfaces/http/dto/budget.dto.ts
@@ -1,5 +1,9 @@
-export interface UpdateBudgetRequestDto {
-  amount: number;
-  targetDate?: string;
-  reason?: string;
-}
+import { z } from 'zod';
+
+export const updateBudgetSchema = z.object({
+  amount: z.number().nonnegative(),
+  targetDate: z.coerce.date().optional(),
+  reason: z.string().max(255).optional(),
+});
+
+export type UpdateBudgetRequestDto = z.infer<typeof updateBudgetSchema>;

--- a/Backend/src/interfaces/http/dto/currency.dto.ts
+++ b/Backend/src/interfaces/http/dto/currency.dto.ts
@@ -1,5 +1,9 @@
-export interface ConvertCurrencyRequestDto {
-  from: string;
-  to: string;
-  amount: number;
-}
+import { z } from 'zod';
+
+export const convertCurrencySchema = z.object({
+  from: z.string().min(1),
+  to: z.string().min(1),
+  amount: z.coerce.number().nonnegative(),
+});
+
+export type ConvertCurrencyRequestDto = z.infer<typeof convertCurrencySchema>;

--- a/Backend/src/interfaces/http/dto/household.dto.ts
+++ b/Backend/src/interfaces/http/dto/household.dto.ts
@@ -1,12 +1,17 @@
-export interface CreateHouseholdRequestDto {
-  name: string;
-  baseCurrency: string;
-}
+import { z } from 'zod';
 
-export interface InviteRequestDto {
-  email: string;
-}
+export const createHouseholdSchema = z.object({
+  name: z.string().min(1),
+  baseCurrency: z.string().min(1),
+});
+export type CreateHouseholdRequestDto = z.infer<typeof createHouseholdSchema>;
 
-export interface AcceptInvitationRequestDto {
-  token: string;
-}
+export const inviteSchema = z.object({
+  email: z.string().email(),
+});
+export type InviteRequestDto = z.infer<typeof inviteSchema>;
+
+export const acceptInvitationSchema = z.object({
+  token: z.string().min(1),
+});
+export type AcceptInvitationRequestDto = z.infer<typeof acceptInvitationSchema>;

--- a/Backend/src/interfaces/http/dto/item.dto.ts
+++ b/Backend/src/interfaces/http/dto/item.dto.ts
@@ -1,25 +1,29 @@
+import { z } from 'zod';
 import { ItemPriority } from '../../../domain/models/enums/item-priority.enum';
 import { ItemStatus } from '../../../domain/models/enums/item-status.enum';
 import { ItemType } from '../../../domain/models/enums/item-type.enum';
 import { PaymentSplit } from '../../../domain/models/payment-split.model';
 
-export interface CreateItemRequestDto {
-  name: string;
-  description?: string;
-  categoryId?: string;
-  type: ItemType;
-  price: number;
-  currency: string;
-  purchaseLink?: string;
-  imageUrls?: string[];
-  status: ItemStatus;
-  priority: ItemPriority;
-  paymentSplit?: PaymentSplit;
-  estimatedPurchaseDate?: Date;
-  purchasedAt?: Date;
-  tags?: string[];
-  lastModifiedByName?: string;
-  metadata?: Record<string, unknown>;
-}
+export const createItemSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  categoryId: z.string().optional(),
+  type: z.nativeEnum(ItemType),
+  price: z.number().nonnegative(),
+  currency: z.string().min(1),
+  purchaseLink: z.string().url().optional(),
+  imageUrls: z.array(z.string().url()).optional(),
+  status: z.nativeEnum(ItemStatus),
+  priority: z.nativeEnum(ItemPriority),
+  paymentSplit: z.custom<PaymentSplit>().optional(),
+  estimatedPurchaseDate: z.coerce.date().optional(),
+  purchasedAt: z.coerce.date().optional(),
+  tags: z.array(z.string()).optional(),
+  lastModifiedByName: z.string().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
 
-export type UpdateItemRequestDto = Partial<CreateItemRequestDto>;
+export type CreateItemRequestDto = z.infer<typeof createItemSchema>;
+
+export const updateItemSchema = createItemSchema.partial();
+export type UpdateItemRequestDto = z.infer<typeof updateItemSchema>;

--- a/Backend/src/interfaces/http/dto/notification-preferences.dto.ts
+++ b/Backend/src/interfaces/http/dto/notification-preferences.dto.ts
@@ -1,10 +1,20 @@
-export interface NotificationPreferencesDto {
-  alerts?: {
-    budgetExceeded?: boolean;
-    monthlyServiceReminder?: boolean;
-  };
-  mediums?: string[];
-  thresholds?: {
-    budgetUsage?: number;
-  };
-}
+import { z } from 'zod';
+
+export const notificationPreferencesSchema = z.object({
+  alerts: z
+    .object({
+      budgetExceeded: z.boolean().optional(),
+      monthlyServiceReminder: z.boolean().optional(),
+    })
+    .optional(),
+  mediums: z.array(z.string()).optional(),
+  thresholds: z
+    .object({
+      budgetUsage: z.number().min(0).max(1).optional(),
+    })
+    .optional(),
+});
+
+export type NotificationPreferencesDto = z.infer<
+  typeof notificationPreferencesSchema
+>;

--- a/Backend/src/interfaces/http/routes/auth.routes.ts
+++ b/Backend/src/interfaces/http/routes/auth.routes.ts
@@ -9,6 +9,8 @@ import { LinkGoogleUseCase } from '../../../application/use-cases/link-google.us
 import { OAuth2Client } from 'google-auth-library';
 import { config } from '../../../config/env';
 import { authMiddleware } from '../../middleware/auth.middleware';
+import { validate } from '../../middleware/validation.middleware';
+import { registerSchema, loginSchema, googleSchema } from '../dto/auth.dto';
 
 const router = Router();
 
@@ -33,12 +35,17 @@ const controller = new AuthController(
   jwtService,
 );
 
-router.post('/register', controller.register);
-router.post('/login', controller.login);
-router.post('/google', controller.google);
+router.post(
+  '/register',
+  validate({ body: registerSchema }),
+  controller.register,
+);
+router.post('/login', validate({ body: loginSchema }), controller.login);
+router.post('/google', validate({ body: googleSchema }), controller.google);
 router.post(
   '/google/link',
   authMiddleware(jwtService),
+  validate({ body: googleSchema }),
   controller.linkGoogleAccount,
 );
 

--- a/Backend/src/interfaces/http/routes/budget.routes.ts
+++ b/Backend/src/interfaces/http/routes/budget.routes.ts
@@ -7,7 +7,9 @@ import { GetBudgetSummaryUseCase } from '../../../application/use-cases/get-budg
 import { UpdateBudgetGoalUseCase } from '../../../application/use-cases/update-budget-goal.usecase';
 import { JwtService } from '../../../infrastructure/auth/jwt.service';
 import { authMiddleware } from '../../middleware/auth.middleware';
+import { validate } from '../../middleware/validation.middleware';
 import { domainEventBus } from '../../../infrastructure/events/domain-event-bus';
+import { updateBudgetSchema } from '../dto/budget.dto';
 
 const router = Router({ mergeParams: true });
 
@@ -25,6 +27,11 @@ const controller = new BudgetController(getSummary, updateGoal);
 const jwtService = new JwtService();
 
 router.get('/', authMiddleware(jwtService), controller.summary);
-router.put('/:type', authMiddleware(jwtService), controller.update);
+router.put(
+  '/:type',
+  authMiddleware(jwtService),
+  validate({ body: updateBudgetSchema }),
+  controller.update,
+);
 
 export default router;

--- a/Backend/src/interfaces/http/routes/currency.routes.ts
+++ b/Backend/src/interfaces/http/routes/currency.routes.ts
@@ -3,6 +3,8 @@ import { CurrencyController } from '../controllers/currency.controller';
 import { ExchangeRateRepository } from '../../../infrastructure/persistence/repositories/exchange-rate.repository';
 import { ExchangeRateProvider } from '../../../infrastructure/currency/exchange-rate.provider';
 import { ConvertCurrencyUseCase } from '../../../application/use-cases/convert-currency.usecase';
+import { validate } from '../../middleware/validation.middleware';
+import { convertCurrencySchema } from '../dto/currency.dto';
 
 const router = Router();
 
@@ -11,6 +13,10 @@ const provider = new ExchangeRateProvider();
 const useCase = new ConvertCurrencyUseCase(repo, provider);
 const controller = new CurrencyController(useCase);
 
-router.get('/convert', controller.convert);
+router.get(
+  '/convert',
+  validate({ query: convertCurrencySchema }),
+  controller.convert,
+);
 
 export default router;

--- a/Backend/src/interfaces/http/routes/household.routes.ts
+++ b/Backend/src/interfaces/http/routes/household.routes.ts
@@ -11,6 +11,8 @@ import { InviteToHouseholdUseCase } from '../../../application/use-cases/invite-
 import { RevokeMembershipUseCase } from '../../../application/use-cases/revoke-membership.usecase';
 import { CancelInvitationUseCase } from '../../../application/use-cases/cancel-invitation.usecase';
 import { EmailService } from '../../../infrastructure/notifications/email.service';
+import { validate } from '../../middleware/validation.middleware';
+import { createHouseholdSchema, inviteSchema } from '../dto/household.dto';
 
 const router = Router();
 
@@ -45,10 +47,16 @@ const controller = new HouseholdController(
   cancelInvitation,
 );
 
-router.post('/', authMiddleware(jwtService), controller.create);
+router.post(
+  '/',
+  authMiddleware(jwtService),
+  validate({ body: createHouseholdSchema }),
+  controller.create,
+);
 router.post(
   '/:householdId/invitations',
   authMiddleware(jwtService),
+  validate({ body: inviteSchema }),
   controller.invite,
 );
 router.delete(

--- a/Backend/src/interfaces/http/routes/invitation.routes.ts
+++ b/Backend/src/interfaces/http/routes/invitation.routes.ts
@@ -5,6 +5,8 @@ import { HouseholdMembershipRepository } from '../../../infrastructure/persisten
 import { JwtService } from '../../../infrastructure/auth/jwt.service';
 import { authMiddleware } from '../../middleware/auth.middleware';
 import { AcceptInvitationUseCase } from '../../../application/use-cases/accept-invitation.usecase';
+import { validate } from '../../middleware/validation.middleware';
+import { acceptInvitationSchema } from '../dto/household.dto';
 
 const router = Router();
 
@@ -19,6 +21,11 @@ const acceptInvitation = new AcceptInvitationUseCase(
 
 const controller = new InvitationController(acceptInvitation);
 
-router.post('/accept', authMiddleware(jwtService), controller.accept);
+router.post(
+  '/accept',
+  authMiddleware(jwtService),
+  validate({ body: acceptInvitationSchema }),
+  controller.accept,
+);
 
 export default router;

--- a/Backend/src/interfaces/http/routes/item.routes.ts
+++ b/Backend/src/interfaces/http/routes/item.routes.ts
@@ -2,12 +2,14 @@ import { Router } from 'express';
 import { ItemRepository } from '../../../infrastructure/persistence/repositories/item.repository';
 import { JwtService } from '../../../infrastructure/auth/jwt.service';
 import { authMiddleware } from '../../middleware/auth.middleware';
+import { validate } from '../../middleware/validation.middleware';
 import { CreateItemUseCase } from '../../../application/use-cases/create-item.usecase';
 import { ListItemsUseCase } from '../../../application/use-cases/list-items.usecase';
 import { UpdateItemUseCase } from '../../../application/use-cases/update-item.usecase';
 import { DeleteItemUseCase } from '../../../application/use-cases/delete-item.usecase';
 import { domainEventBus } from '../../../infrastructure/events/domain-event-bus';
 import { ItemController } from '../controllers/item.controller';
+import { createItemSchema, updateItemSchema } from '../dto/item.dto';
 
 const router = Router({ mergeParams: true });
 
@@ -27,8 +29,18 @@ const controller = new ItemController(
 );
 
 router.get('/', authMiddleware(jwtService), controller.list);
-router.post('/', authMiddleware(jwtService), controller.create);
-router.put('/:itemId', authMiddleware(jwtService), controller.update);
+router.post(
+  '/',
+  authMiddleware(jwtService),
+  validate({ body: createItemSchema }),
+  controller.create,
+);
+router.put(
+  '/:itemId',
+  authMiddleware(jwtService),
+  validate({ body: updateItemSchema }),
+  controller.update,
+);
 router.delete('/:itemId', authMiddleware(jwtService), controller.delete);
 
 export default router;

--- a/Backend/src/interfaces/http/routes/notification-preferences.routes.ts
+++ b/Backend/src/interfaces/http/routes/notification-preferences.routes.ts
@@ -5,6 +5,8 @@ import { GetNotificationPreferencesUseCase } from '../../../application/use-case
 import { UpdateNotificationPreferencesUseCase } from '../../../application/use-cases/update-notification-preferences.usecase';
 import { JwtService } from '../../../infrastructure/auth/jwt.service';
 import { authMiddleware } from '../../middleware/auth.middleware';
+import { validate } from '../../middleware/validation.middleware';
+import { notificationPreferencesSchema } from '../dto/notification-preferences.dto';
 
 const router = Router({ mergeParams: true });
 
@@ -16,6 +18,11 @@ const controller = new NotificationPreferencesController(getPrefs, updatePrefs);
 const jwtService = new JwtService();
 
 router.get('/', authMiddleware(jwtService), controller.get);
-router.put('/', authMiddleware(jwtService), controller.update);
+router.put(
+  '/',
+  authMiddleware(jwtService),
+  validate({ body: notificationPreferencesSchema }),
+  controller.update,
+);
 
 export default router;

--- a/Backend/src/interfaces/middleware/validation.middleware.ts
+++ b/Backend/src/interfaces/middleware/validation.middleware.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction } from 'express';
+import { AnyZodObject, ZodError } from 'zod';
+
+interface Schema {
+  body?: AnyZodObject;
+  query?: AnyZodObject;
+  params?: AnyZodObject;
+}
+
+export const validate = (schema: Schema) => {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    try {
+      if (schema.body) {
+        req.body = schema.body.parse(req.body);
+      }
+      if (schema.query) {
+        req.query = schema.query.parse(req.query);
+      }
+      if (schema.params) {
+        req.params = schema.params.parse(req.params);
+      }
+      next();
+    } catch (err) {
+      const error = err as ZodError;
+      res.status(400).json({ error: 'Validation error', issues: error.issues });
+    }
+  };
+};


### PR DESCRIPTION
## Summary
- add Zod-powered validation middleware for bodies, params and queries
- validate authentication, household, item, budget and other routes using schemas
- parse dates and typed payloads before updating budget goals

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68901d3c720c8326b79bbae419079275