### PR TITLE
feat: add configurable API base URL for frontend

### DIFF
--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -1,0 +1,1 @@
+NG_APP_API_URL=http://localhost:3000/api/v1

--- a/Frontend/src/app/app.config.ts
+++ b/Frontend/src/app/app.config.ts
@@ -8,12 +8,13 @@ import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { routes } from './app.routes';
 import { authInterceptor } from './core/auth/auth.interceptor';
+import { apiUrlInterceptor } from './core/http/api-url.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient(withInterceptors([authInterceptor])),
+    provideHttpClient(withInterceptors([apiUrlInterceptor, authInterceptor])),
   ],
 };

--- a/Frontend/src/app/core/auth/auth.service.spec.ts
+++ b/Frontend/src/app/core/auth/auth.service.spec.ts
@@ -7,6 +7,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { AuthService } from './auth.service';
 
+const API_URL = (import.meta as any).env['NG_APP_API_URL'] as string;
+
 describe('AuthService', () => {
   let service: AuthService;
   let httpMock: HttpTestingController;
@@ -26,7 +28,7 @@ describe('AuthService', () => {
 
   it('stores tokens on login', () => {
     service.login('test@example.com', '123456').subscribe();
-    const req = httpMock.expectOne('/auth/login');
+    const req = httpMock.expectOne(`${API_URL}/auth/login`);
     req.flush({
       user: {
         id: '1',

--- a/Frontend/src/app/core/http/api-url.interceptor.ts
+++ b/Frontend/src/app/core/http/api-url.interceptor.ts
@@ -1,0 +1,10 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+
+const apiUrl = (import.meta as any).env['NG_APP_API_URL'] ?? '';
+
+export const apiUrlInterceptor: HttpInterceptorFn = (req, next) => {
+  if (!req.url.startsWith('http')) {
+    req = req.clone({ url: `${apiUrl}${req.url}` });
+  }
+  return next(req);
+};


### PR DESCRIPTION
## Summary
- add `NG_APP_API_URL` variable to frontend
- prefix HTTP requests with a new API URL interceptor
- register interceptor and update auth service tests

## Testing
- `npm ci`
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6891604543348326bb714d1adb80a964