### PR TITLE
Lee URL de la API desde variable de entorno

### DIFF
--- a/Frontend/src/app/core/auth/auth.service.spec.ts
+++ b/Frontend/src/app/core/auth/auth.service.spec.ts
@@ -7,7 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { AuthService } from './auth.service';
 
-const API_URL = (import.meta as any).env['NG_APP_API_URL'] as string;
+const API_URL = import.meta.env.NG_APP_API_URL;
 
 describe('AuthService', () => {
   let service: AuthService;

--- a/Frontend/src/app/core/http/api-url.interceptor.ts
+++ b/Frontend/src/app/core/http/api-url.interceptor.ts
@@ -1,6 +1,6 @@
 import { HttpInterceptorFn } from '@angular/common/http';
 
-const apiUrl = (import.meta as any).env['NG_APP_API_URL'] ?? '';
+const apiUrl = import.meta.env.NG_APP_API_URL ?? '';
 
 export const apiUrlInterceptor: HttpInterceptorFn = (req, next) => {
   if (!req.url.startsWith('http')) {

--- a/Frontend/src/env.d.ts
+++ b/Frontend/src/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly NG_APP_API_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- Usa `NG_APP_API_URL` para anteponer la URL base de la API en el interceptor HTTP
- Expone el tipo de `import.meta.env` y ajusta las pruebas de autenticación

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run build`
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_689165d17ffc8326bf7e4e67427bd603