### PR TITLE
feat: centralize backend error handling

### DIFF
--- a/Backend/src/application/use-cases/accept-invitation.usecase.ts
+++ b/Backend/src/application/use-cases/accept-invitation.usecase.ts
@@ -4,6 +4,8 @@ import { InvitationStatus } from '../../domain/models/enums/invitation-status.en
 import { MembershipStatus } from '../../domain/models/enums/membership-status.enum';
 import { MembershipRole } from '../../domain/models/enums/membership-role.enum';
 import { HouseholdMembership } from '../../domain/models/household-membership.model';
+import { BadRequestError } from '../../domain/errors/bad-request.error';
+import { ConflictError } from '../../domain/errors/conflict.error';
 
 export class AcceptInvitationUseCase {
   constructor(
@@ -14,7 +16,7 @@ export class AcceptInvitationUseCase {
   async execute(token: string, userId: string): Promise<HouseholdMembership> {
     const invitation = await this.invitationRepo.findByToken(token);
     if (!invitation || invitation.status !== InvitationStatus.PENDING) {
-      throw new Error('Invitación inválida');
+      throw new BadRequestError('Invitación inválida');
     }
 
     if (invitation.expiresAt && invitation.expiresAt < new Date()) {
@@ -22,7 +24,7 @@ export class AcceptInvitationUseCase {
         status: InvitationStatus.EXPIRED,
         usageAttempts: invitation.usageAttempts + 1,
       });
-      throw new Error('Invitación expirada');
+      throw new BadRequestError('Invitación expirada');
     }
 
     await this.invitationRepo.update(invitation.id, {
@@ -40,7 +42,7 @@ export class AcceptInvitationUseCase {
         MembershipStatus.ACTIVE,
       );
       if (!updated) {
-        throw new Error('No se pudo actualizar la membresía');
+        throw new ConflictError('No se pudo actualizar la membresía');
       }
       return updated;
     }

--- a/Backend/src/application/use-cases/cancel-invitation.usecase.ts
+++ b/Backend/src/application/use-cases/cancel-invitation.usecase.ts
@@ -4,6 +4,8 @@ import { UserRepository } from '../../infrastructure/persistence/repositories/us
 import { InvitationStatus } from '../../domain/models/enums/invitation-status.enum';
 import { MembershipRole } from '../../domain/models/enums/membership-role.enum';
 import { MembershipStatus } from '../../domain/models/enums/membership-status.enum';
+import { UnauthorizedError } from '../../domain/errors/unauthorized.error';
+import { NotFoundError } from '../../domain/errors/not-found.error';
 
 export class CancelInvitationUseCase {
   constructor(
@@ -26,12 +28,12 @@ export class CancelInvitationUseCase {
       inviter.role !== MembershipRole.ADMIN ||
       inviter.status !== MembershipStatus.ACTIVE
     ) {
-      throw new Error('No autorizado');
+      throw new UnauthorizedError('No autorizado');
     }
 
     const invitation = await this.invitationRepo.findById(invitationId);
     if (!invitation || invitation.householdId !== householdId) {
-      throw new Error('Invitación no encontrada');
+      throw new NotFoundError('Invitación no encontrada');
     }
 
     if (invitation.status !== InvitationStatus.PENDING) {

--- a/Backend/src/application/use-cases/google-auth.usecase.ts
+++ b/Backend/src/application/use-cases/google-auth.usecase.ts
@@ -3,6 +3,7 @@ import { UserRepository } from '../../infrastructure/persistence/repositories/us
 import { JwtService } from '../../infrastructure/auth/jwt.service';
 import { User } from '../../domain/models/user.model';
 import { UserStatus } from '../../domain/models/enums/user-status.enum';
+import { UnauthorizedError } from '../../domain/errors/unauthorized.error';
 
 export class GoogleAuthUseCase {
   constructor(
@@ -17,7 +18,7 @@ export class GoogleAuthUseCase {
     const ticket = await this.googleClient.verifyIdToken({ idToken });
     const payload = ticket.getPayload();
     if (!payload?.sub || !payload.email || !payload.name) {
-      throw new Error('Token de Google inválido');
+      throw new UnauthorizedError('Token de Google inválido');
     }
     const externalId = payload.sub;
     const email = payload.email;

--- a/Backend/src/application/use-cases/invite-to-household.usecase.ts
+++ b/Backend/src/application/use-cases/invite-to-household.usecase.ts
@@ -7,6 +7,7 @@ import { MembershipRole } from '../../domain/models/enums/membership-role.enum';
 import { MembershipStatus } from '../../domain/models/enums/membership-status.enum';
 import { InvitationStatus } from '../../domain/models/enums/invitation-status.enum';
 import { Invitation } from '../../domain/models/invitation.model';
+import { UnauthorizedError } from '../../domain/errors/unauthorized.error';
 
 export class InviteToHouseholdUseCase {
   constructor(
@@ -30,7 +31,7 @@ export class InviteToHouseholdUseCase {
       inviter.role !== MembershipRole.ADMIN ||
       inviter.status !== MembershipStatus.ACTIVE
     ) {
-      throw new Error('No autorizado');
+      throw new UnauthorizedError('No autorizado');
     }
 
     const token = randomUUID();

--- a/Backend/src/application/use-cases/link-google.usecase.ts
+++ b/Backend/src/application/use-cases/link-google.usecase.ts
@@ -1,6 +1,8 @@
 import { OAuth2Client } from 'google-auth-library';
 import { UserRepository } from '../../infrastructure/persistence/repositories/user.repository';
 import { User } from '../../domain/models/user.model';
+import { UnauthorizedError } from '../../domain/errors/unauthorized.error';
+import { NotFoundError } from '../../domain/errors/not-found.error';
 
 export class LinkGoogleUseCase {
   constructor(
@@ -12,12 +14,12 @@ export class LinkGoogleUseCase {
     const ticket = await this.googleClient.verifyIdToken({ idToken });
     const payload = ticket.getPayload();
     if (!payload?.sub) {
-      throw new Error('Token de Google inválido');
+      throw new UnauthorizedError('Token de Google inválido');
     }
     const externalId = payload.sub;
     const user = await this.userRepository.findById(userId);
     if (!user) {
-      throw new Error('Usuario no encontrado');
+      throw new NotFoundError('Usuario no encontrado');
     }
     if (user.oauthProviders.some((p) => p.provider === 'google')) {
       return user;

--- a/Backend/src/application/use-cases/login-user.usecase.ts
+++ b/Backend/src/application/use-cases/login-user.usecase.ts
@@ -1,6 +1,7 @@
 import bcrypt from 'bcryptjs';
 import { UserRepository } from '../../infrastructure/persistence/repositories/user.repository';
 import { JwtService } from '../../infrastructure/auth/jwt.service';
+import { UnauthorizedError } from '../../domain/errors/unauthorized.error';
 
 export class LoginUserUseCase {
   constructor(
@@ -11,11 +12,11 @@ export class LoginUserUseCase {
   async execute(email: string, password: string) {
     const user = await this.userRepository.findByEmail(email);
     if (!user || !user.passwordHash) {
-      throw new Error('Credenciales inválidas');
+      throw new UnauthorizedError('Credenciales inválidas');
     }
     const valid = await bcrypt.compare(password, user.passwordHash);
     if (!valid) {
-      throw new Error('Credenciales inválidas');
+      throw new UnauthorizedError('Credenciales inválidas');
     }
     const { accessToken, refreshToken } = this.jwtService.generateTokens(user);
     return { user, accessToken, refreshToken };

--- a/Backend/src/application/use-cases/register-user.usecase.ts
+++ b/Backend/src/application/use-cases/register-user.usecase.ts
@@ -2,6 +2,7 @@ import bcrypt from 'bcryptjs';
 import { UserRepository } from '../../infrastructure/persistence/repositories/user.repository';
 import { UserStatus } from '../../domain/models/enums/user-status.enum';
 import { User } from '../../domain/models/user.model';
+import { ConflictError } from '../../domain/errors/conflict.error';
 
 export class RegisterUserUseCase {
   constructor(private userRepository: UserRepository) {}
@@ -13,7 +14,7 @@ export class RegisterUserUseCase {
   ): Promise<User> {
     const existing = await this.userRepository.findByEmail(email);
     if (existing) {
-      throw new Error('Correo electrónico ya en uso');
+      throw new ConflictError('Correo electrónico ya en uso');
     }
     const passwordHash = await bcrypt.hash(password, 10);
     const user = await this.userRepository.create({

--- a/Backend/src/application/use-cases/revoke-membership.usecase.ts
+++ b/Backend/src/application/use-cases/revoke-membership.usecase.ts
@@ -1,6 +1,8 @@
 import { HouseholdMembershipRepository } from '../../infrastructure/persistence/repositories/household-membership.repository';
 import { MembershipRole } from '../../domain/models/enums/membership-role.enum';
 import { MembershipStatus } from '../../domain/models/enums/membership-status.enum';
+import { UnauthorizedError } from '../../domain/errors/unauthorized.error';
+import { NotFoundError } from '../../domain/errors/not-found.error';
 
 export class RevokeMembershipUseCase {
   constructor(private membershipRepo: HouseholdMembershipRepository) {}
@@ -19,12 +21,12 @@ export class RevokeMembershipUseCase {
       admin.role !== MembershipRole.ADMIN ||
       admin.status !== MembershipStatus.ACTIVE
     ) {
-      throw new Error('No autorizado');
+      throw new UnauthorizedError('No autorizado');
     }
 
     const target = await this.membershipRepo.findById(memberId);
     if (!target || target.householdId !== householdId) {
-      throw new Error('Membresía no encontrada');
+      throw new NotFoundError('Membresía no encontrada');
     }
 
     await this.membershipRepo.updateStatus(target.id, MembershipStatus.REVOKED);

--- a/Backend/src/domain/errors/bad-request.error.ts
+++ b/Backend/src/domain/errors/bad-request.error.ts
@@ -1,0 +1,6 @@
+export class BadRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BadRequestError';
+  }
+}

--- a/Backend/src/domain/errors/conflict.error.ts
+++ b/Backend/src/domain/errors/conflict.error.ts
@@ -1,0 +1,6 @@
+export class ConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConflictError';
+  }
+}

--- a/Backend/src/domain/errors/external-service.error.ts
+++ b/Backend/src/domain/errors/external-service.error.ts
@@ -1,0 +1,6 @@
+export class ExternalServiceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ExternalServiceError';
+  }
+}

--- a/Backend/src/domain/errors/not-found.error.ts
+++ b/Backend/src/domain/errors/not-found.error.ts
@@ -1,0 +1,6 @@
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+}

--- a/Backend/src/domain/errors/unauthorized.error.ts
+++ b/Backend/src/domain/errors/unauthorized.error.ts
@@ -1,0 +1,6 @@
+export class UnauthorizedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnauthorizedError';
+  }
+}

--- a/Backend/src/infrastructure/currency/exchange-rate.provider.ts
+++ b/Backend/src/infrastructure/currency/exchange-rate.provider.ts
@@ -1,4 +1,5 @@
 import { config } from '../../config/env';
+import { ExternalServiceError } from '../../domain/errors/external-service.error';
 
 interface FetchRateResult {
   rate: number;
@@ -15,14 +16,14 @@ export class ExchangeRateProvider {
     const url = `${this.apiBase}/latest?base=${baseCurrency}&symbols=${targetCurrency}`;
     const response = await fetch(url);
     if (!response.ok) {
-      throw new Error('Failed to fetch exchange rate');
+      throw new ExternalServiceError('Failed to fetch exchange rate');
     }
     const data = (await response.json()) as {
       rates?: Record<string, number>;
     };
     const rate = data.rates?.[targetCurrency];
     if (typeof rate !== 'number') {
-      throw new Error('Invalid exchange rate data');
+      throw new ExternalServiceError('Invalid exchange rate data');
     }
     return { rate, source: this.apiBase };
   }

--- a/Backend/src/interfaces/http/controllers/alert.controller.ts
+++ b/Backend/src/interfaces/http/controllers/alert.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { ListAlertsUseCase } from '../../../application/use-cases/list-alerts.usecase';
 import { MarkAlertReadUseCase } from '../../../application/use-cases/mark-alert-read.usecase';
+import { NotFoundError } from '../../../domain/errors/not-found.error';
 
 interface AuthRequest extends Request {
   userId: string;
@@ -24,7 +25,7 @@ export class AlertController {
     const userId = (req as AuthRequest).userId;
     const alert = await this.markAlertReadUseCase.execute(alertId, userId);
     if (!alert) {
-      return res.status(404).json({ error: 'Alert not found' });
+      throw new NotFoundError('Alert not found');
     }
     res.json({ alert });
   };

--- a/Backend/src/interfaces/http/controllers/budget.controller.ts
+++ b/Backend/src/interfaces/http/controllers/budget.controller.ts
@@ -7,6 +7,7 @@ import {
 import { BudgetGoalType } from '../../../domain/models/enums/budget-goal-type.enum';
 import { UpdateBudgetRequestDto } from '../dto/budget.dto';
 import { notifyHousehold } from '../../../infrastructure/websocket/socket.service';
+import { NotFoundError } from '../../../domain/errors/not-found.error';
 
 interface AuthRequest extends Request {
   userId: string;
@@ -22,7 +23,7 @@ export class BudgetController {
     const { householdId } = req.params as { householdId: string };
     const summary = await this.getSummary.execute(householdId);
     if (!summary) {
-      return res.status(404).json({ error: 'Household not found' });
+      throw new NotFoundError('Household not found');
     }
     res.json({ summary });
   };
@@ -48,7 +49,7 @@ export class BudgetController {
       updatePayload,
     );
     if (!result) {
-      return res.status(404).json({ error: 'Household not found' });
+      throw new NotFoundError('Household not found');
     }
     notifyHousehold(householdId, 'budget:goal_updated', {
       type,

--- a/Backend/src/interfaces/http/controllers/item.controller.ts
+++ b/Backend/src/interfaces/http/controllers/item.controller.ts
@@ -11,6 +11,7 @@ import {
 import { DeleteItemUseCase } from '../../../application/use-cases/delete-item.usecase';
 import { CreateItemRequestDto, UpdateItemRequestDto } from '../dto/item.dto';
 import { notifyHousehold } from '../../../infrastructure/websocket/socket.service';
+import { NotFoundError } from '../../../domain/errors/not-found.error';
 
 interface AuthRequest extends Request {
   userId: string;
@@ -53,7 +54,7 @@ export class ItemController {
       payload as UpdateItemPayload,
     );
     if (!item) {
-      return res.status(404).json({ error: 'Item not found' });
+      throw new NotFoundError('Item not found');
     }
     notifyHousehold(item.householdId, 'item:updated', item);
     res.json({ item });
@@ -64,7 +65,7 @@ export class ItemController {
     const userId = (req as AuthRequest).userId;
     const item = await this.deleteItem.execute(userId, itemId);
     if (!item) {
-      return res.status(404).json({ error: 'Item not found' });
+      throw new NotFoundError('Item not found');
     }
     notifyHousehold(item.householdId, 'item:deleted', { id: itemId });
     res.status(204).send();

--- a/Backend/src/interfaces/http/middleware/error-handler.middleware.ts
+++ b/Backend/src/interfaces/http/middleware/error-handler.middleware.ts
@@ -1,0 +1,41 @@
+import { NextFunction, Request, Response } from 'express';
+import { ZodError } from 'zod';
+import { UnauthorizedError } from '../../../domain/errors/unauthorized.error';
+import { NotFoundError } from '../../../domain/errors/not-found.error';
+import { ConflictError } from '../../../domain/errors/conflict.error';
+import { BadRequestError } from '../../../domain/errors/bad-request.error';
+import { InvalidPaymentSplitError } from '../../../domain/errors/invalid-payment-split.error';
+import { ExternalServiceError } from '../../../domain/errors/external-service.error';
+
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _next: NextFunction,
+) {
+  if (err instanceof ZodError) {
+    const message = err.errors.map((e) => e.message).join(', ');
+    return res.status(400).json({ error: message });
+  }
+  if (
+    err instanceof BadRequestError ||
+    err instanceof InvalidPaymentSplitError
+  ) {
+    return res.status(400).json({ error: err.message });
+  }
+  if (err instanceof UnauthorizedError) {
+    return res.status(401).json({ error: err.message });
+  }
+  if (err instanceof NotFoundError) {
+    return res.status(404).json({ error: err.message });
+  }
+  if (err instanceof ConflictError) {
+    return res.status(409).json({ error: err.message });
+  }
+  if (err instanceof ExternalServiceError) {
+    return res.status(502).json({ error: err.message });
+  }
+  console.error(err);
+  return res.status(500).json({ error: 'Internal server error' });
+}

--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -14,6 +14,7 @@ import alertRoutes from './interfaces/http/routes/alert.routes';
 import { initSocket } from './infrastructure/websocket/socket.service';
 import './infrastructure/events/changelog.subscriber';
 import './infrastructure/events/alerts.subscriber';
+import { errorHandler } from './interfaces/http/middleware/error-handler.middleware';
 
 const app = express();
 app.use(express.json());
@@ -38,6 +39,8 @@ app.use('/api/v1/currency', currencyRoutes);
 app.get('/', (_req, res) => {
   res.send('API de Nidify');
 });
+
+app.use(errorHandler);
 
 server.listen(config.port, () => {
   console.log(`Servidor ejecutándose en el puerto ${config.port}`);


### PR DESCRIPTION
## Summary
- add custom domain error classes and global error-handler middleware
- return 401 for invalid login credentials and proper codes for common failures
- propagate not-found errors through controllers instead of inline responses

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68917c8dcfc88326b609cb6ba0b4baa5