### PR TITLE
feat(core): add global problem details handling

### DIFF
--- a/Frontend/src/app/app.config.ts
+++ b/Frontend/src/app/app.config.ts
@@ -2,19 +2,18 @@ import {
   ApplicationConfig,
   provideBrowserGlobalErrorListeners,
   provideZoneChangeDetection,
+  importProvidersFrom,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { routes } from './app.routes';
-import { authInterceptor } from './core/auth/auth.interceptor';
-import { apiUrlInterceptor } from './core/http/api-url.interceptor';
+import { CoreModule } from './core/core.module';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient(withInterceptors([apiUrlInterceptor, authInterceptor])),
+    importProvidersFrom(CoreModule),
   ],
 };

--- a/Frontend/src/app/core/config/problem-handlers.config.ts
+++ b/Frontend/src/app/core/config/problem-handlers.config.ts
@@ -1,0 +1,35 @@
+import { Router } from '@angular/router';
+import { ProblemDetails } from '../../shared/models/problem-details.model';
+
+export type ProblemHandler = (problem: ProblemDetails, router: Router) => void;
+
+export const problemHandlers: Record<number, ProblemHandler> = {
+  401: redirectToLogin,
+  403: redirectToLogin,
+  404: notFound,
+  409: conflict,
+  429: tooManyRequests,
+};
+
+export const defaultProblemHandler: ProblemHandler = (problem: ProblemDetails) => {
+  // eslint-disable-next-line no-console
+  console.error('Unhandled problem', problem);
+};
+
+function redirectToLogin(_: ProblemDetails, router: Router): void {
+  router.navigate(['/login']);
+}
+
+function notFound(_: ProblemDetails, router: Router): void {
+  router.navigate(['/not-found']);
+}
+
+function conflict(problem: ProblemDetails): void {
+  // eslint-disable-next-line no-console
+  console.warn('Conflict', problem);
+}
+
+function tooManyRequests(problem: ProblemDetails): void {
+  // eslint-disable-next-line no-console
+  console.warn('Too many requests', problem);
+}

--- a/Frontend/src/app/core/core.module.ts
+++ b/Frontend/src/app/core/core.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+
+import { apiUrlInterceptor } from './http/api-url.interceptor';
+import { authInterceptor } from './auth/auth.interceptor';
+import { problemHttpInterceptor } from './interceptors/problem-http.interceptor';
+
+@NgModule({
+  providers: [
+    provideHttpClient(
+      withInterceptors([apiUrlInterceptor, authInterceptor, problemHttpInterceptor])
+    ),
+  ],
+})
+export class CoreModule {}

--- a/Frontend/src/app/core/interceptors/problem-http.interceptor.spec.ts
+++ b/Frontend/src/app/core/interceptors/problem-http.interceptor.spec.ts
@@ -1,0 +1,58 @@
+import { HttpClient, HttpErrorResponse, HttpHeaders, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ProblemDetails } from '../../shared/models/problem-details.model';
+import { ProblemHandlerService } from '../services/problem-handler.service';
+import { problemHttpInterceptor } from './problem-http.interceptor';
+
+describe('problemHttpInterceptor', () => {
+  let http: HttpClient;
+  let controller: HttpTestingController;
+  let handler: jasmine.SpyObj<ProblemHandlerService>;
+
+  beforeEach(() => {
+    handler = jasmine.createSpyObj('ProblemHandlerService', ['handle']);
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ProblemHandlerService, useValue: handler },
+        provideHttpClient(withInterceptors([problemHttpInterceptor])),
+        provideHttpClientTesting(),
+      ],
+    });
+    http = TestBed.inject(HttpClient);
+    controller = TestBed.inject(HttpTestingController);
+  });
+
+  it('should normalize problem details', (done) => {
+    http.get('/test').subscribe({
+      next: () => fail('expected error'),
+      error: (err: HttpErrorResponse) => {
+        const problem = err.error as ProblemDetails;
+        expect(problem.status).toBe(400);
+        expect(problem.detail).toBe('Invalid');
+        expect(problem.traceId).toBe('trace-123');
+        expect(handler.handle).toHaveBeenCalled();
+        done();
+      },
+    });
+
+    const req = controller.expectOne('/test');
+    req.flush(
+      {
+        type: 'https://example.com/error',
+        title: 'Bad Request',
+        status: 400,
+        detail: 'Invalid',
+      },
+      {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: new HttpHeaders({
+          'Content-Type': 'application/problem+json',
+          'X-Trace-Id': 'trace-123',
+        }),
+      }
+    );
+  });
+});

--- a/Frontend/src/app/core/interceptors/problem-http.interceptor.ts
+++ b/Frontend/src/app/core/interceptors/problem-http.interceptor.ts
@@ -1,0 +1,88 @@
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { catchError, throwError } from 'rxjs';
+
+import { ProblemHandlerService } from '../services/problem-handler.service';
+import { ProblemDetails } from '../../shared/models/problem-details.model';
+
+export const problemHttpInterceptor: HttpInterceptorFn = (req, next) => {
+  const problemHandler = inject(ProblemHandlerService);
+
+  return next(req).pipe(
+    catchError((error: HttpErrorResponse) => {
+      const contentType = error.headers.get('Content-Type') ?? '';
+      let problem: ProblemDetails | null = null;
+
+      if (contentType.includes('application/problem+json')) {
+        problem = parseProblemDetails(error);
+      }
+
+      if (!problem && typeof error.error === 'object' && error.error !== null) {
+        problem = parseProblemDetails(error);
+      }
+
+      if (!problem) {
+        problem = fallbackProblemDetails(error);
+      }
+
+      problemHandler.handle(problem);
+
+      const newError = new HttpErrorResponse({
+        ...error,
+        url: error.url ?? undefined,
+        error: problem,
+      });
+
+      return throwError(() => newError);
+    })
+  );
+};
+
+function parseProblemDetails(error: HttpErrorResponse): ProblemDetails {
+  const body = (error.error && typeof error.error === 'object') ? error.error : {};
+  const {
+    type,
+    title,
+    status,
+    detail,
+    instance,
+    traceId,
+    correlationId,
+    ...extensions
+  } = body as Record<string, unknown>;
+
+  const headerTrace =
+    error.headers.get('traceid') ||
+    error.headers.get('x-trace-id') ||
+    error.headers.get('correlationid') ||
+    error.headers.get('x-correlation-id');
+
+  const problem: ProblemDetails = {
+    type: typeof type === 'string' ? (type as string) : undefined,
+    title: typeof title === 'string' ? (title as string) : undefined,
+    status: typeof status === 'number' ? (status as number) : error.status,
+    detail: typeof detail === 'string' ? (detail as string) : undefined,
+    instance: typeof instance === 'string' ? (instance as string) : error.url ?? undefined,
+    traceId: (traceId as string) || (correlationId as string) || headerTrace || undefined,
+  };
+
+  return { ...problem, ...extensions };
+}
+
+function fallbackProblemDetails(error: HttpErrorResponse): ProblemDetails {
+  return {
+    title: error.statusText || 'Unknown Error',
+    status: error.status || 0,
+    detail:
+      typeof error.error === 'string'
+        ? error.error
+        : error.message,
+    traceId:
+      error.headers.get('traceid') ||
+      error.headers.get('x-trace-id') ||
+      error.headers.get('correlationid') ||
+      error.headers.get('x-correlation-id') ||
+      undefined,
+    instance: error.url ?? undefined,
+  };
+}

--- a/Frontend/src/app/core/services/problem-handler.service.spec.ts
+++ b/Frontend/src/app/core/services/problem-handler.service.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+
+import { ProblemHandlerService } from './problem-handler.service';
+import { TelemetryService } from './telemetry.service';
+import { ProblemDetails } from '../../shared/models/problem-details.model';
+
+describe('ProblemHandlerService', () => {
+  let service: ProblemHandlerService;
+  let router: jasmine.SpyObj<Router>;
+  let telemetry: jasmine.SpyObj<TelemetryService>;
+
+  beforeEach(() => {
+    router = jasmine.createSpyObj('Router', ['navigate']);
+    telemetry = jasmine.createSpyObj('TelemetryService', ['log']);
+    TestBed.configureTestingModule({
+      providers: [
+        ProblemHandlerService,
+        { provide: Router, useValue: router },
+        { provide: TelemetryService, useValue: telemetry },
+      ],
+    });
+    service = TestBed.inject(ProblemHandlerService);
+  });
+
+  it('should emit problems', (done) => {
+    service.problems$.subscribe((p: ProblemDetails) => {
+      expect(p.status).toBe(500);
+      done();
+    });
+    service.handle({ status: 500, title: 'error' });
+  });
+
+  it('should redirect to login on 401', () => {
+    service.handle({ status: 401 });
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+  });
+});

--- a/Frontend/src/app/core/services/problem-handler.service.ts
+++ b/Frontend/src/app/core/services/problem-handler.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { Subject } from 'rxjs';
+
+import { ProblemDetails } from '../../shared/models/problem-details.model';
+import { TelemetryService } from './telemetry.service';
+import {
+  defaultProblemHandler,
+  problemHandlers,
+} from '../config/problem-handlers.config';
+
+@Injectable({ providedIn: 'root' })
+export class ProblemHandlerService {
+  private readonly problemSubject = new Subject<ProblemDetails>();
+  readonly problems$ = this.problemSubject.asObservable();
+
+  constructor(
+    private readonly router: Router,
+    private readonly telemetry: TelemetryService
+  ) {}
+
+  handle(problem: ProblemDetails): void {
+    this.telemetry.log(problem);
+    const handler = problemHandlers[problem.status ?? 0] ?? defaultProblemHandler;
+    handler(problem, this.router);
+    this.problemSubject.next(problem);
+  }
+}

--- a/Frontend/src/app/core/services/telemetry.service.ts
+++ b/Frontend/src/app/core/services/telemetry.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { ProblemDetails } from '../../shared/models/problem-details.model';
+
+@Injectable({ providedIn: 'root' })
+export class TelemetryService {
+  log(problem: ProblemDetails): void {
+    const { traceId, status, type, detail, instance } = problem;
+    // In real scenario, send to telemetry backend and redact sensitive data
+    // Here we just log to console
+    // eslint-disable-next-line no-console
+    console.log('telemetry', { traceId, status, type, detail, instance });
+  }
+}

--- a/Frontend/src/app/features/auth/login/login.component.html
+++ b/Frontend/src/app/features/auth/login/login.component.html
@@ -31,7 +31,7 @@
         <a class="link" routerLink="/register">Crear cuenta nueva</a>
       </div>
 
-      <div *ngIf="errorMessage" class="alert-error" role="alert">{{ errorMessage }}</div>
+      <app-problem-inline></app-problem-inline>
     </form>
   </div>
 </div>

--- a/Frontend/src/app/features/auth/login/login.component.spec.ts
+++ b/Frontend/src/app/features/auth/login/login.component.spec.ts
@@ -1,24 +1,35 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
 
+import { ProblemHandlerService } from '../../../core/services/problem-handler.service';
+import { ProblemDetails } from '../../../shared/models/problem-details.model';
 import { LoginComponent } from './login.component';
 
+class ProblemHandlerStub {
+  private readonly subject = new Subject<ProblemDetails>();
+  readonly problems$ = this.subject.asObservable();
+  handle(problem: ProblemDetails): void {
+    this.subject.next(problem);
+  }
+}
+
 describe('LoginComponent', () => {
-  let component: LoginComponent;
-  let fixture: ComponentFixture<LoginComponent>;
+  let handler: ProblemHandlerStub;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [LoginComponent, HttpClientTestingModule, RouterTestingModule],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(LoginComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(() => {
+    handler = new ProblemHandlerStub();
+    TestBed.configureTestingModule({
+      imports: [LoginComponent],
+      providers: [{ provide: ProblemHandlerService, useValue: handler }],
+    });
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should display error from handler', () => {
+    const fixture = TestBed.createComponent(LoginComponent);
+    fixture.detectChanges();
+    handler.handle({ status: 400, detail: 'Invalid credentials' });
+    fixture.detectChanges();
+    const alert: HTMLElement | null = fixture.nativeElement.querySelector('.alert-error');
+    expect(alert?.textContent).toContain('Invalid credentials');
   });
 });

--- a/Frontend/src/app/features/auth/login/login.component.ts
+++ b/Frontend/src/app/features/auth/login/login.component.ts
@@ -10,15 +10,14 @@ import {
 } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { HttpErrorResponse } from '@angular/common/http';
 
 import { AuthService } from '../../../core/auth/auth.service';
-import { ProblemDetail } from '../../../core/http/problem-detail.model';
+import { ProblemInlineComponent } from '../../../shared/components/problem-inline/problem-inline.component';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, ProblemInlineComponent],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -27,8 +26,6 @@ export class LoginComponent {
   private readonly fb = inject(FormBuilder);
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
-
-  errorMessage: string | null = null;
 
   readonly form = this.fb.nonNullable.group({
     email: ['', [Validators.required, Validators.email]],
@@ -41,14 +38,9 @@ export class LoginComponent {
       return;
     }
     const { email, password } = this.form.getRawValue();
-    this.errorMessage = null;
     this.authService.login(email, password).subscribe({
       next: () => {
         this.router.navigate(['/home']);
-      },
-      error: (err: HttpErrorResponse) => {
-        const problem = err.error as ProblemDetail;
-        this.errorMessage = problem.detail || 'Unexpected error';
       },
     });
   }

--- a/Frontend/src/app/features/auth/register/register.component.html
+++ b/Frontend/src/app/features/auth/register/register.component.html
@@ -39,7 +39,7 @@
         <a class="link" routerLink="/login">Ya tengo cuenta</a>
       </div>
 
-      <div *ngIf="errorMessage" class="alert-error" role="alert">{{ errorMessage }}</div>
+      <app-problem-inline></app-problem-inline>
     </form>
   </div>
 </div>

--- a/Frontend/src/app/features/auth/register/register.component.ts
+++ b/Frontend/src/app/features/auth/register/register.component.ts
@@ -10,15 +10,14 @@ import {
 } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { HttpErrorResponse } from '@angular/common/http';
 
 import { AuthService } from '../../../core/auth/auth.service';
-import { ProblemDetail } from '../../../core/http/problem-detail.model';
+import { ProblemInlineComponent } from '../../../shared/components/problem-inline/problem-inline.component';
 
 @Component({
   selector: 'app-register',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, ProblemInlineComponent],
   templateUrl: './register.component.html',
   styleUrl: './register.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -27,8 +26,6 @@ export class RegisterComponent {
   private readonly fb = inject(FormBuilder);
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
-
-  errorMessage: string | null = null;
 
   readonly form = this.fb.nonNullable.group({
     name: ['', Validators.required],
@@ -42,14 +39,9 @@ export class RegisterComponent {
       return;
     }
     const { name, email, password } = this.form.getRawValue();
-    this.errorMessage = null;
     this.authService.register(name, email, password).subscribe({
       next: () => {
         this.router.navigate(['/home']);
-      },
-      error: (err: HttpErrorResponse) => {
-        const problem = err.error as ProblemDetail;
-        this.errorMessage = problem.detail || 'Unexpected error';
       },
     });
   }

--- a/Frontend/src/app/shared/components/problem-inline/problem-inline.component.html
+++ b/Frontend/src/app/shared/components/problem-inline/problem-inline.component.html
@@ -1,0 +1,3 @@
+<div *ngIf="problem$ | async as problem" class="alert-error" role="alert" aria-live="assertive">
+  {{ problem.detail }}
+</div>

--- a/Frontend/src/app/shared/components/problem-inline/problem-inline.component.scss
+++ b/Frontend/src/app/shared/components/problem-inline/problem-inline.component.scss
@@ -1,0 +1,3 @@
+.alert-error {
+  color: #b00020;
+}

--- a/Frontend/src/app/shared/components/problem-inline/problem-inline.component.ts
+++ b/Frontend/src/app/shared/components/problem-inline/problem-inline.component.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+} from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ProblemHandlerService } from '../../../core/services/problem-handler.service';
+import { ProblemDetails } from '../../models/problem-details.model';
+
+@Component({
+  selector: 'app-problem-inline',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './problem-inline.component.html',
+  styleUrl: './problem-inline.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProblemInlineComponent {
+  private readonly problemHandler = inject(ProblemHandlerService);
+  readonly problem$: Observable<ProblemDetails> = this.problemHandler.problems$;
+}

--- a/Frontend/src/app/shared/components/problem-modal/problem-modal.component.html
+++ b/Frontend/src/app/shared/components/problem-modal/problem-modal.component.html
@@ -1,0 +1,5 @@
+<div *ngIf="problem$ | async as problem" class="modal" role="dialog" aria-modal="true">
+  <div class="modal-content">
+    <p>{{ problem.detail }}</p>
+  </div>
+</div>

--- a/Frontend/src/app/shared/components/problem-modal/problem-modal.component.scss
+++ b/Frontend/src/app/shared/components/problem-modal/problem-modal.component.scss
@@ -1,0 +1,17 @@
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+}

--- a/Frontend/src/app/shared/components/problem-modal/problem-modal.component.ts
+++ b/Frontend/src/app/shared/components/problem-modal/problem-modal.component.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+} from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ProblemHandlerService } from '../../../core/services/problem-handler.service';
+import { ProblemDetails } from '../../models/problem-details.model';
+
+@Component({
+  selector: 'app-problem-modal',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './problem-modal.component.html',
+  styleUrl: './problem-modal.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProblemModalComponent {
+  private readonly handler = inject(ProblemHandlerService);
+  readonly problem$: Observable<ProblemDetails> = this.handler.problems$;
+}

--- a/Frontend/src/app/shared/components/problem-snackbar/problem-snackbar.component.html
+++ b/Frontend/src/app/shared/components/problem-snackbar/problem-snackbar.component.html
@@ -1,0 +1,3 @@
+<div *ngIf="problem$ | async as problem" class="snackbar" role="status" aria-live="polite">
+  {{ problem.detail }}
+</div>

--- a/Frontend/src/app/shared/components/problem-snackbar/problem-snackbar.component.scss
+++ b/Frontend/src/app/shared/components/problem-snackbar/problem-snackbar.component.scss
@@ -1,0 +1,10 @@
+.snackbar {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #323232;
+  color: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+}

--- a/Frontend/src/app/shared/components/problem-snackbar/problem-snackbar.component.ts
+++ b/Frontend/src/app/shared/components/problem-snackbar/problem-snackbar.component.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+} from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ProblemHandlerService } from '../../../core/services/problem-handler.service';
+import { ProblemDetails } from '../../models/problem-details.model';
+
+@Component({
+  selector: 'app-problem-snackbar',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './problem-snackbar.component.html',
+  styleUrl: './problem-snackbar.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProblemSnackbarComponent {
+  private readonly handler = inject(ProblemHandlerService);
+  readonly problem$: Observable<ProblemDetails> = this.handler.problems$;
+}

--- a/Frontend/src/app/shared/models/problem-details.model.ts
+++ b/Frontend/src/app/shared/models/problem-details.model.ts
@@ -1,7 +1,9 @@
-export interface ProblemDetail {
+export interface ProblemDetails {
   type?: string;
   title?: string;
   status?: number;
   detail?: string;
   instance?: string;
+  traceId?: string;
+  [key: string]: unknown;
 }

--- a/Frontend/src/testing/fixtures/problem-details/bad-request.json
+++ b/Frontend/src/testing/fixtures/problem-details/bad-request.json
@@ -1,0 +1,8 @@
+{
+  "type": "https://example.com/validation-error",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "Invalid request",
+  "instance": "/test",
+  "traceId": "abc123"
+}


### PR DESCRIPTION
## Summary
- normalize RFC 9457 responses via ProblemHttpInterceptor
- centralize HTTP problem policies in ProblemHandlerService with telemetry
- add reusable components to surface problem details in UI

## Testing
- `npm test -- --watch=false` *(fails: Chrome binary missing)*
- `npm run build`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68951164e654832699afdef2a0a154ac