### PR TITLE
Secure token storage and session refresh

### DIFF
--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/cookie-parser": "^1.4.3",
         "bcryptjs": "^3.0.2",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
@@ -442,7 +444,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -453,7 +454,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -464,6 +464,15 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/cors": {
       "version": "2.8.19",
@@ -495,7 +504,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
       "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -507,7 +515,6 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
       "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -520,7 +527,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -545,7 +551,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ms": {
@@ -568,21 +573,18 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "0.17.5",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
       "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -593,7 +595,6 @@
       "version": "1.15.8",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
       "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -1354,6 +1355,34 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -20,7 +20,9 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@types/cookie-parser": "^1.4.3",
     "bcryptjs": "^3.0.2",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",

--- a/Backend/src/interfaces/http/dto/auth.dto.ts
+++ b/Backend/src/interfaces/http/dto/auth.dto.ts
@@ -17,8 +17,3 @@ export const googleSchema = z.object({
   idToken: z.string().min(1),
 });
 export type GoogleRequestDto = z.infer<typeof googleSchema>;
-
-export const refreshSchema = z.object({
-  refreshToken: z.string().min(1),
-});
-export type RefreshRequestDto = z.infer<typeof refreshSchema>;

--- a/Backend/src/interfaces/http/routes/auth.routes.ts
+++ b/Backend/src/interfaces/http/routes/auth.routes.ts
@@ -10,12 +10,7 @@ import { OAuth2Client } from 'google-auth-library';
 import { config } from '../../../config/env';
 import { authMiddleware } from '../../middleware/auth.middleware';
 import { validate } from '../../middleware/validation.middleware';
-import {
-  registerSchema,
-  loginSchema,
-  googleSchema,
-  refreshSchema,
-} from '../dto/auth.dto';
+import { registerSchema, loginSchema, googleSchema } from '../dto/auth.dto';
 
 const router = Router();
 
@@ -47,7 +42,8 @@ router.post(
 );
 router.post('/login', validate({ body: loginSchema }), controller.login);
 router.post('/google', validate({ body: googleSchema }), controller.google);
-router.post('/refresh', validate({ body: refreshSchema }), controller.refresh);
+router.post('/refresh', controller.refresh);
+router.post('/logout', controller.logout);
 router.post(
   '/google/link',
   authMiddleware(jwtService),

--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import cors from 'cors';
+import cookieParser from 'cookie-parser';
 import http from 'http';
 import { config } from './config/env';
 import { connectMongo } from './infrastructure/persistence/mongoose-connection';
@@ -18,7 +19,13 @@ import './infrastructure/events/alerts.subscriber';
 import { errorHandler } from './interfaces/http/middleware/error-handler.middleware';
 
 const app = express();
-app.use(cors());
+app.use(
+  cors({
+    origin: true,
+    credentials: true,
+  }),
+);
+app.use(cookieParser());
 app.use(express.json());
 
 const server = http.createServer(app);

--- a/Frontend/src/app/core/auth/auth.guard.ts
+++ b/Frontend/src/app/core/auth/auth.guard.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
+import { map, Observable } from 'rxjs';
 
 import { AuthService } from './auth.service';
 
@@ -7,11 +8,14 @@ import { AuthService } from './auth.service';
 export class AuthGuard implements CanActivate {
   constructor(private authService: AuthService, private router: Router) {}
 
-  canActivate(): boolean {
-    if (this.authService.isAuthenticated()) {
-      return true;
-    }
-    this.router.navigate(['/login']);
-    return false;
+  canActivate(): Observable<boolean> {
+    return this.authService.ensureSession().pipe(
+      map((ok) => {
+        if (!ok) {
+          this.router.navigate(['/login']);
+        }
+        return ok;
+      }),
+    );
   }
 }

--- a/Frontend/src/app/core/auth/auth.service.spec.ts
+++ b/Frontend/src/app/core/auth/auth.service.spec.ts
@@ -7,8 +7,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { AuthService } from './auth.service';
 
-const API_URL = import.meta.env.NG_APP_API_URL;
-
 describe('AuthService', () => {
   let service: AuthService;
   let httpMock: HttpTestingController;
@@ -26,9 +24,10 @@ describe('AuthService', () => {
     localStorage.clear();
   });
 
-  it('stores tokens on login', () => {
+  it('stores access token in memory and user in storage on login', () => {
     service.login('test@example.com', '123456').subscribe();
-    const req = httpMock.expectOne(`${API_URL}/auth/login`);
+    const req = httpMock.expectOne('/auth/login');
+    expect(req.request.withCredentials).toBeTrue();
     req.flush({
       user: {
         id: '1',
@@ -37,10 +36,10 @@ describe('AuthService', () => {
         roles: ['admin'],
       },
       accessToken: 'token',
-      refreshToken: 'refresh',
     });
 
-    expect(localStorage.getItem('accessToken')).toBe('token');
-    expect(localStorage.getItem('refreshToken')).toBe('refresh');
+    expect(service.getToken()).toBe('token');
+    expect(localStorage.getItem('user')).toContain('Test User');
+    expect(localStorage.getItem('accessToken')).toBeNull();
   });
 });

--- a/Frontend/src/app/core/http/api-url.interceptor.ts
+++ b/Frontend/src/app/core/http/api-url.interceptor.ts
@@ -2,8 +2,10 @@ import { HttpInterceptorFn } from "@angular/common/http";
 import { environment } from "../../../environments/environment";
 
 export const apiUrlInterceptor: HttpInterceptorFn = (req, next) => {
-  if (!req.url.startsWith("http")) {
-    req = req.clone({ url: `${environment.apiUrl}${req.url}` });
+  if (!req.url.startsWith('http')) {
+    req = req.clone({ url: `${environment.apiUrl}${req.url}`, withCredentials: true });
+  } else {
+    req = req.clone({ withCredentials: true });
   }
   return next(req);
 };


### PR DESCRIPTION
## Summary
- store refresh token in secure HTTP-only cookie
- keep access token in memory with auto-refresh on user activity
- ensure session restoration via AuthGuard and in-memory token

## Testing
- `npm test` *(backend)*
- `npm run lint` *(backend)*
- `CHROME_BIN=chromium-browser npm test -- --watch=false --browsers=ChromeHeadless` *(frontend) - fails: ChromeHeadless requires snap*
- `npm run lint` *(frontend) - fails: Missing script "lint"*

------
https://chatgpt.com/codex/tasks/task_e_689559dc669083269f41e9fabcc76733