### PR TITLE
Handle missing refresh token and adjust cookie security

### DIFF
--- a/Backend/src/config/env.ts
+++ b/Backend/src/config/env.ts
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 export const config = {
+  nodeEnv: process.env.NODE_ENV ?? 'development',
   port: Number(process.env.PORT ?? 3000),
   mongoUri: process.env.MONGODB_URI ?? 'mongodb://localhost:27017/nidify',
   jwtSecret: process.env.JWT_SECRET ?? 'changeme',


### PR DESCRIPTION
## Summary
- read NODE_ENV in backend config
- throw `UnauthorizedError` when refresh token is missing or invalid
- use env-based secure flag for auth cookies

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68957c0967308326b219860e29888b5e