### PR TITLE
Evita refresh de token sin sesión

### DIFF
--- a/Frontend/src/app/core/auth/auth.service.spec.ts
+++ b/Frontend/src/app/core/auth/auth.service.spec.ts
@@ -42,4 +42,16 @@ describe('AuthService', () => {
     expect(localStorage.getItem('user')).toContain('Test User');
     expect(localStorage.getItem('accessToken')).toBeNull();
   });
+
+  it('does not refresh token on activity when unauthenticated', () => {
+    document.dispatchEvent(new Event('click'));
+    httpMock.expectNone('/auth/refresh');
+  });
+
+  it('refreshes token on activity when expired', () => {
+    (service as any).accessToken = 'x.eyJleHAiOjB9.y';
+    document.dispatchEvent(new Event('click'));
+    const refresh = httpMock.expectOne('/auth/refresh');
+    refresh.flush({ accessToken: 'newAccess' });
+  });
 });

--- a/Frontend/src/app/core/auth/auth.service.ts
+++ b/Frontend/src/app/core/auth/auth.service.ts
@@ -121,7 +121,11 @@ export class AuthService {
   }
 
   private handleActivity(): void {
-    if (this.isTokenExpired(this.accessToken, 120_000) && !this.refreshing) {
+    if (
+      this.accessToken &&
+      this.isTokenExpired(this.accessToken, 120_000) &&
+      !this.refreshing
+    ) {
       this.refreshing = true;
       this.refreshTokens()
         .pipe(finalize(() => (this.refreshing = false)))


### PR DESCRIPTION
## Summary
- Evita refresh token al detectar actividad si no hay access token
- Añade pruebas para verificar refresh solo cuando el token existe y está expirado

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(falla: No binary for ChromeHeadless)*
- `npm run lint` *(falla: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68957e945e8083269da828a353e40211