### PR TITLE
fix: avoid refresh token on unauthenticated login errors

### DIFF
--- a/Frontend/src/app/core/interceptors/auth-http.interceptor.spec.ts
+++ b/Frontend/src/app/core/interceptors/auth-http.interceptor.spec.ts
@@ -74,4 +74,17 @@ describe('authHttpInterceptor', () => {
     expect(retry2.request.headers.get('Authorization')).toBe('Bearer newAccess');
     retry2.flush('ok2');
   });
+
+  it('does not attempt to refresh when no token is present', (done) => {
+    http.post('/auth/login', {}).subscribe({
+      error: (err) => {
+        expect(err.status).toBe(401);
+        controller.expectNone('/auth/refresh');
+        done();
+      },
+    });
+
+    const login = controller.expectOne('/auth/login');
+    login.flush(null, { status: 401, statusText: 'Unauthorized' });
+  });
 });

--- a/Frontend/src/app/core/interceptors/auth-http.interceptor.ts
+++ b/Frontend/src/app/core/interceptors/auth-http.interceptor.ts
@@ -24,6 +24,7 @@ export const authHttpInterceptor: HttpInterceptorFn = (req, next) => {
     catchError((error: HttpErrorResponse): Observable<HttpEvent<unknown>> => {
       if (
         error.status === 401 &&
+        token &&
         !req.url.includes('/auth/refresh') &&
         auth.isTokenExpired(token)
       ) {


### PR DESCRIPTION
## Summary
- skip refresh token logic when no access token is present
- add test ensuring refresh is not attempted on login failures

## Testing
- `npm ci`
- `npm run build`
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_6895843632088326afd99f875eb6c094