### PR TITLE
Add onboarding household guard

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from "@angular/router";
 import { AuthGuard } from "./core/auth/auth.guard";
+import { HouseholdGuard } from "./core/household/household.guard";
 
 export const routes: Routes = [
   {
@@ -25,7 +26,7 @@ export const routes: Routes = [
   },
   {
     path: "home",
-    canActivate: [AuthGuard],
+    canActivate: [AuthGuard, HouseholdGuard],
     loadComponent: () =>
       import("./features/home/home.component").then((m) => m.HomeComponent),
     children: [

--- a/Frontend/src/app/core/auth/auth.service.ts
+++ b/Frontend/src/app/core/auth/auth.service.ts
@@ -13,6 +13,7 @@ import {
 } from "rxjs";
 
 import { User } from "./user.model";
+import { HouseholdService } from "../household/household.service";
 
 interface LoginRequest {
   email: string;
@@ -34,6 +35,7 @@ interface AuthResponse {
 export class AuthService {
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
+  private readonly householdService = inject(HouseholdService);
 
   private accessToken: string | null = null;
   private refreshing = false;
@@ -66,6 +68,7 @@ export class AuthService {
     this.accessToken = null;
     localStorage.removeItem("user");
     this.userSubject.next(null);
+    this.householdService.clear();
     void this.http
       .post("/auth/logout", {}, { withCredentials: true })
       .subscribe();

--- a/Frontend/src/app/core/household/household.guard.spec.ts
+++ b/Frontend/src/app/core/household/household.guard.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { HouseholdGuard } from './household.guard';
+import { HouseholdService } from './household.service';
+
+describe('HouseholdGuard', () => {
+  let guard: HouseholdGuard;
+  let router: Router;
+  let service: jasmine.SpyObj<HouseholdService>;
+
+  beforeEach(() => {
+    service = jasmine.createSpyObj('HouseholdService', ['hasHousehold']);
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [{ provide: HouseholdService, useValue: service }],
+    });
+    guard = TestBed.inject(HouseholdGuard);
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate');
+  });
+
+  it('allows navigation when household exists', () => {
+    service.hasHousehold.and.returnValue(true);
+    expect(guard.canActivate()).toBeTrue();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('redirects to onboarding when no household', () => {
+    service.hasHousehold.and.returnValue(false);
+    expect(guard.canActivate()).toBeFalse();
+    expect(router.navigate).toHaveBeenCalledWith(['/onboarding']);
+  });
+});

--- a/Frontend/src/app/core/household/household.guard.ts
+++ b/Frontend/src/app/core/household/household.guard.ts
@@ -1,0 +1,17 @@
+import { Injectable, inject } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { HouseholdService } from './household.service';
+
+@Injectable({ providedIn: 'root' })
+export class HouseholdGuard implements CanActivate {
+  private readonly householdService = inject(HouseholdService);
+  private readonly router = inject(Router);
+
+  canActivate(): boolean {
+    const ok = this.householdService.hasHousehold();
+    if (!ok) {
+      this.router.navigate(['/onboarding']);
+    }
+    return ok;
+  }
+}

--- a/Frontend/src/app/core/household/household.service.ts
+++ b/Frontend/src/app/core/household/household.service.ts
@@ -1,0 +1,52 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, map, Observable, tap } from 'rxjs';
+
+export interface Household {
+  id: string;
+  name: string;
+  baseCurrency: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class HouseholdService {
+  private readonly http = inject(HttpClient);
+  private readonly householdIdSubject = new BehaviorSubject<string | null>(
+    localStorage.getItem('householdId')
+  );
+  readonly householdId$ = this.householdIdSubject.asObservable();
+
+  hasHousehold(): boolean {
+    return !!this.householdIdSubject.value;
+  }
+
+  getHouseholdId(): string | null {
+    return this.householdIdSubject.value;
+  }
+
+  createHousehold(name: string, baseCurrency: string): Observable<Household> {
+    return this.http
+      .post<{ household: Household }>('/households', { name, baseCurrency })
+      .pipe(tap(({ household }) => this.setHousehold(household.id)), map(({ household }) => household));
+  }
+
+  acceptInvitation(token: string): Observable<string> {
+    return this.http
+      .post<{ membership: { householdId: string } }>('/invitations/accept', { token })
+      .pipe(
+        tap(({ membership }) => this.setHousehold(membership.householdId)),
+        map(({ membership }) => membership.householdId)
+      );
+  }
+
+  clear(): void {
+    localStorage.removeItem('householdId');
+    this.householdIdSubject.next(null);
+  }
+
+  private setHousehold(id: string): void {
+    localStorage.setItem('householdId', id);
+    this.householdIdSubject.next(id);
+  }
+}
+

--- a/Frontend/src/app/features/onboarding/onboarding.component.html
+++ b/Frontend/src/app/features/onboarding/onboarding.component.html
@@ -11,50 +11,50 @@
     </div>
 
     <div class="grid">
-        <div class="card action-card">
+        <form class="card action-card" [formGroup]="createForm" (ngSubmit)="onCreate()">
             <h3>Crear hogar</h3>
             <p class="text-muted">Define el nombre, moneda base y metas presupuestales.</p>
             <div class="form-grid">
                 <label>
                     Nombre del hogar
-                    <input type="text" placeholder="Ej. Andrés y Julia" />
+                    <input type="text" formControlName="name" placeholder="Ej. Andrés y Julia" />
                 </label>
                 <label>
                     Moneda base
-                    <select>
-                        <option>USD</option>
-                        <option>EUR</option>
-                        <option>ARS</option>
-                        <option>MXN</option>
+                    <select formControlName="baseCurrency">
+                        <option value="USD">USD</option>
+                        <option value="EUR">EUR</option>
+                        <option value="ARS">ARS</option>
+                        <option value="MXN">MXN</option>
                     </select>
                 </label>
                 <label>
                     Presupuesto inicial (opcional)
-                    <input type="number" placeholder="0" />
+                    <input type="number" formControlName="initialBudget" placeholder="0" />
                 </label>
                 <label>
                     Presupuesto mensual (opcional)
-                    <input type="number" placeholder="0" />
+                    <input type="number" formControlName="monthlyBudget" placeholder="0" />
                 </label>
             </div>
             <div class="form-actions">
-                <a routerLink="/home" class="btn btn-primary btn-block">Crear hogar</a>
+                <button type="submit" class="btn btn-primary btn-block">Crear hogar</button>
             </div>
-        </div>
+        </form>
 
-        <div class="card action-card">
+        <form class="card action-card" [formGroup]="inviteForm" (ngSubmit)="onAccept()">
             <h3>Aceptar invitación</h3>
             <p class="text-muted">Pega tu token o link de invitación para unirte.</p>
             <div class="form-grid">
                 <label>
                     Token / Link
-                    <input type="text" placeholder="nidify://invite?token=..." />
+                    <input type="text" formControlName="token" placeholder="nidify://invite?token=..." />
                 </label>
             </div>
             <div class="form-actions">
-                <a routerLink="/home" class="btn btn-primary btn-block">Unirme al hogar</a>
+                <button type="submit" class="btn btn-primary btn-block">Unirme al hogar</button>
             </div>
-        </div>
+        </form>
     </div>
 
     <div class="foot text-muted">

--- a/Frontend/src/app/features/onboarding/onboarding.component.ts
+++ b/Frontend/src/app/features/onboarding/onboarding.component.ts
@@ -1,13 +1,51 @@
-import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { RouterLink } from "@angular/router";
+import { ReactiveFormsModule, FormBuilder, Validators } from "@angular/forms";
+import { Router } from "@angular/router";
+
+import { HouseholdService } from "../../core/household/household.service";
 
 @Component({
   selector: "app-onboarding",
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule, ReactiveFormsModule],
   templateUrl: "./onboarding.component.html",
   styleUrl: "./onboarding.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class OnboardingComponent {}
+export class OnboardingComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly householdService = inject(HouseholdService);
+  private readonly router = inject(Router);
+
+  readonly createForm = this.fb.nonNullable.group({
+    name: ["", [Validators.required]],
+    baseCurrency: ["USD", [Validators.required]],
+    initialBudget: [0],
+    monthlyBudget: [0],
+  });
+
+  readonly inviteForm = this.fb.nonNullable.group({
+    token: ["", [Validators.required]],
+  });
+
+  onCreate(): void {
+    if (this.createForm.invalid) {
+      return;
+    }
+    const { name, baseCurrency } = this.createForm.getRawValue();
+    this.householdService.createHousehold(name, baseCurrency).subscribe(() => {
+      this.router.navigate(["/home"]);
+    });
+  }
+
+  onAccept(): void {
+    if (this.inviteForm.invalid) {
+      return;
+    }
+    const { token } = this.inviteForm.getRawValue();
+    this.householdService.acceptInvitation(token).subscribe(() => {
+      this.router.navigate(["/home"]);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- redirect users without household to onboarding using HouseholdGuard
- integrate onboarding forms with backend to create or join household
- persist and clear household id via HouseholdService

## Testing
- `npm ci`
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6896971fd8888326beb2e316397b8fd3