### PR TITLE
feat: add invitation handling on frontend

### DIFF
--- a/Frontend/src/app/core/household/household.service.ts
+++ b/Frontend/src/app/core/household/household.service.ts
@@ -8,6 +8,13 @@ export interface Household {
   baseCurrency: string;
 }
 
+export interface Invitation {
+  id: string;
+  email: string;
+  token: string;
+  expiresAt?: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class HouseholdService {
   private readonly http = inject(HttpClient);
@@ -28,6 +35,22 @@ export class HouseholdService {
     return this.http
       .post<{ household: Household }>('/households', { name, baseCurrency })
       .pipe(tap(({ household }) => this.setHousehold(household.id)), map(({ household }) => household));
+  }
+
+  invite(email: string): Observable<Invitation> {
+    const householdId = this.getHouseholdId();
+    return this.http
+      .post<{ invitation: Invitation }>(`/households/${householdId}/invitations`, {
+        email,
+      })
+      .pipe(map(({ invitation }) => invitation));
+  }
+
+  cancelInvitation(invitationId: string): Observable<void> {
+    const householdId = this.getHouseholdId();
+    return this.http.delete<void>(
+      `/households/${householdId}/invitations/${invitationId}`,
+    );
   }
 
   acceptInvitation(token: string): Observable<string> {

--- a/Frontend/src/app/features/dashboard/invitations/invitations.component.html
+++ b/Frontend/src/app/features/dashboard/invitations/invitations.component.html
@@ -1,32 +1,38 @@
 <div class="subheader">
-    <h2>Invitaciones</h2>
-    <div class="actions">
-        <button class="btn">Copiar link de invitación</button>
-    </div>
+  <h2>Invitaciones</h2>
 </div>
 
 <section class="grid">
-    <div class="card">
-        <h3 style="margin:0 0 8px 0; font-size:15px">Invitar a tu pareja</h3>
-        <div class="row">
-            <input class="input" type="email" placeholder="email@ejemplo.com" />
-            <button class="btn primary">Enviar invitación</button>
-        </div>
-    </div>
+  <div class="card">
+    <h3 style="margin:0 0 8px 0; font-size:15px">Invitar a tu pareja</h3>
+    <form class="row" [formGroup]="inviteForm" (ngSubmit)="onInvite()">
+      <input
+        class="input"
+        type="email"
+        formControlName="email"
+        placeholder="email@ejemplo.com"
+      />
+      <button class="btn primary" type="submit">Enviar invitación</button>
+    </form>
+  </div>
 
-    <div class="card">
-        <h3 style="margin:0 0 8px 0; font-size:15px">Invitaciones</h3>
-        <ul class="list">
-            <li class="item">
-                <div>
-                    <div class="title">pendiente@ejemplo.com</div>
-                    <div class="meta">Pendiente • expira en 7 días</div>
-                </div>
-                <div class="actions">
-                    <button class="btn">Copiar link</button>
-                    <button class="btn danger">Cancelar</button>
-                </div>
-            </li>
-        </ul>
-    </div>
+  <div class="card" *ngIf="invitations().length > 0">
+    <h3 style="margin:0 0 8px 0; font-size:15px">Invitaciones</h3>
+    <ul class="list">
+      <li class="item" *ngFor="let inv of invitations()">
+        <div>
+          <div class="title">{{ inv.email }}</div>
+          <div class="meta">Pendiente • {{ getExpiration(inv) }}</div>
+        </div>
+        <div class="actions">
+          <button class="btn" type="button" (click)="copyLink(inv)">
+            Copiar link
+          </button>
+          <button class="btn danger" type="button" (click)="cancel(inv)">
+            Cancelar
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
 </section>

--- a/Frontend/src/app/features/dashboard/invitations/invitations.component.spec.ts
+++ b/Frontend/src/app/features/dashboard/invitations/invitations.component.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { InvitationsComponent } from './invitations.component';
+import { ReactiveFormsModule } from '@angular/forms';
+
+describe('InvitationsComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [InvitationsComponent, HttpClientTestingModule, ReactiveFormsModule],
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(InvitationsComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+});

--- a/Frontend/src/app/features/dashboard/invitations/invitations.component.ts
+++ b/Frontend/src/app/features/dashboard/invitations/invitations.component.ts
@@ -1,12 +1,62 @@
-import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component, inject, signal } from "@angular/core";
 import { CommonModule } from "@angular/common";
+import { ReactiveFormsModule, FormBuilder, Validators } from "@angular/forms";
+
+import {
+  HouseholdService,
+  Invitation,
+} from "../../../core/household/household.service";
 
 @Component({
   selector: "app-invitations",
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ReactiveFormsModule],
   templateUrl: "./invitations.component.html",
   styleUrl: "./invitations.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class InvitationsComponent {}
+export class InvitationsComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly householdService = inject(HouseholdService);
+
+  readonly inviteForm = this.fb.nonNullable.group({
+    email: ["", [Validators.required, Validators.email]],
+  });
+
+  readonly invitations = signal<Invitation[]>([]);
+
+  onInvite(): void {
+    if (this.inviteForm.invalid) {
+      return;
+    }
+    const { email } = this.inviteForm.getRawValue();
+    this.householdService.invite(email).subscribe((invitation) => {
+      this.inviteForm.reset();
+      this.invitations.update((list) => [...list, invitation]);
+    });
+  }
+
+  copyLink(invitation: Invitation): void {
+    const url = `${location.origin}/onboarding?token=${invitation.token}`;
+    navigator.clipboard.writeText(url);
+  }
+
+  cancel(invitation: Invitation): void {
+    this.householdService.cancelInvitation(invitation.id).subscribe(() => {
+      this.invitations.update((list) =>
+        list.filter((i) => i.id !== invitation.id),
+      );
+    });
+  }
+
+  getExpiration(invitation: Invitation): string {
+    if (!invitation.expiresAt) {
+      return "";
+    }
+    const diff = Math.ceil(
+      (new Date(invitation.expiresAt).getTime() - Date.now()) /
+        (1000 * 60 * 60 * 24),
+    );
+    return `expira en ${diff} días`;
+  }
+}

--- a/Frontend/src/app/features/onboarding/onboarding.component.ts
+++ b/Frontend/src/app/features/onboarding/onboarding.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { ReactiveFormsModule, FormBuilder, Validators } from "@angular/forms";
-import { Router } from "@angular/router";
+import { Router, ActivatedRoute } from "@angular/router";
 
 import { HouseholdService } from "../../core/household/household.service";
 
@@ -17,6 +17,7 @@ export class OnboardingComponent {
   private readonly fb = inject(FormBuilder);
   private readonly householdService = inject(HouseholdService);
   private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
 
   readonly createForm = this.fb.nonNullable.group({
     name: ["", [Validators.required]],
@@ -28,6 +29,15 @@ export class OnboardingComponent {
   readonly inviteForm = this.fb.nonNullable.group({
     token: ["", [Validators.required]],
   });
+
+  constructor() {
+    const token = this.route.snapshot.queryParamMap.get("token");
+    if (token) {
+      this.householdService.acceptInvitation(token).subscribe(() => {
+        this.router.navigate(["/home"]);
+      });
+    }
+  }
 
   onCreate(): void {
     if (this.createForm.invalid) {


### PR DESCRIPTION
## Summary
- allow household service to create and cancel invitations
- implement invitations dashboard with email form, link copy and cancel actions
- auto-accept invitation tokens from onboarding URL

## Testing
- `npm ci`
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6896ad91ce048326bf67d0f6e8e839e7