### PR TITLE
feat(frontend): integra autenticación con Google

### DIFF
--- a/Frontend/src/app/core/auth/auth.service.spec.ts
+++ b/Frontend/src/app/core/auth/auth.service.spec.ts
@@ -43,6 +43,39 @@ describe("AuthService", () => {
     expect(localStorage.getItem("accessToken")).toBeNull();
   });
 
+  it("stores session on google login", () => {
+    service.loginWithGoogle("token123").subscribe();
+    const req = httpMock.expectOne("/auth/google");
+    expect(req.request.body).toEqual({ idToken: "token123" });
+    expect(req.request.withCredentials).toBeTrue();
+    req.flush({
+      user: {
+        id: "1",
+        fullName: "Test User",
+        email: "test@example.com",
+        roles: ["user"],
+      },
+      accessToken: "gToken",
+    });
+    expect(service.getToken()).toBe("gToken");
+  });
+
+  it("updates user on google account link", () => {
+    service.linkGoogleAccount("idTok").subscribe();
+    const req = httpMock.expectOne("/auth/google/link");
+    expect(req.request.body).toEqual({ idToken: "idTok" });
+    expect(req.request.withCredentials).toBeTrue();
+    req.flush({
+      user: {
+        id: "1",
+        fullName: "Test User",
+        email: "test@example.com",
+        roles: ["user"],
+      },
+    });
+    expect(localStorage.getItem("user")).toContain("Test User");
+  });
+
   it("does not refresh token on activity when unauthenticated", () => {
     // No hay token cargado, no debe intentar refrescar automáticamente
     httpMock.expectNone("/auth/refresh");

--- a/Frontend/src/app/core/auth/auth.service.ts
+++ b/Frontend/src/app/core/auth/auth.service.ts
@@ -86,11 +86,28 @@ export class AuthService {
       .pipe(tap((res) => this.storeSession(res)));
   }
 
+  loginWithGoogle(idToken: string) {
+    return this.http
+      .post<AuthResponse>("/auth/google", { idToken }, { withCredentials: true })
+      .pipe(tap((res) => this.storeSession(res)));
+  }
+
   register(fullName: string, email: string, password: string) {
     const body: RegisterRequest = { fullName, email, password };
     return this.http
       .post<AuthResponse>("/auth/register", body, { withCredentials: true })
       .pipe(tap((res) => this.storeSession(res)));
+  }
+
+  linkGoogleAccount(idToken: string) {
+    return this.http
+      .post<{ user: User }>("/auth/google/link", { idToken }, { withCredentials: true })
+      .pipe(
+        tap(({ user }) => {
+          localStorage.setItem("user", JSON.stringify(user));
+          this.userSubject.next(user);
+        }),
+      );
   }
 
   logout(): void {

--- a/Frontend/src/app/core/auth/google-auth.service.ts
+++ b/Frontend/src/app/core/auth/google-auth.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
+
+declare global {
+  interface Window {
+    google?: any;
+  }
+}
+
+@Injectable({ providedIn: 'root' })
+export class GoogleAuthService {
+  /**
+   * Initiates the Google identity flow and resolves with the ID token.
+   */
+  signIn(): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const google = window.google?.accounts?.id;
+      if (!google) {
+        reject('Google SDK not loaded');
+        return;
+      }
+      google.initialize({
+        client_id: environment.googleClientId,
+        callback: (res: any) => resolve(res.credential),
+      });
+      google.prompt((notification: any) => {
+        if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
+          reject('User cancelled');
+        }
+      });
+    });
+  }
+}
+

--- a/Frontend/src/app/features/auth/login/login.component.html
+++ b/Frontend/src/app/features/auth/login/login.component.html
@@ -31,6 +31,10 @@
         <a class="link" routerLink="/register">Crear cuenta nueva</a>
       </div>
 
+      <button class="btn btn-secondary btn-block" type="button" (click)="googleLogin()">
+        Ingresar con Google
+      </button>
+
       <app-problem-inline></app-problem-inline>
     </form>
   </div>

--- a/Frontend/src/app/features/auth/login/login.component.ts
+++ b/Frontend/src/app/features/auth/login/login.component.ts
@@ -12,6 +12,7 @@ import { Router, RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
 
 import { AuthService } from '../../../core/auth/auth.service';
+import { GoogleAuthService } from '../../../core/auth/google-auth.service';
 import { ProblemInlineComponent } from '../../../shared/components/problem-inline/problem-inline.component';
 
 @Component({
@@ -25,6 +26,7 @@ import { ProblemInlineComponent } from '../../../shared/components/problem-inlin
 export class LoginComponent {
   private readonly fb = inject(FormBuilder);
   private readonly authService = inject(AuthService);
+  private readonly googleAuth = inject(GoogleAuthService);
   private readonly router = inject(Router);
 
   readonly form = this.fb.nonNullable.group({
@@ -42,6 +44,16 @@ export class LoginComponent {
       next: () => {
         this.router.navigate(['/home']);
       },
+    });
+  }
+
+  googleLogin(): void {
+    this.googleAuth.signIn().then((idToken) => {
+      this.authService.loginWithGoogle(idToken).subscribe({
+        next: () => {
+          this.router.navigate(['/home']);
+        },
+      });
     });
   }
 }

--- a/Frontend/src/app/features/dashboard/preferences/preferences.component.html
+++ b/Frontend/src/app/features/dashboard/preferences/preferences.component.html
@@ -45,4 +45,9 @@
         </div>
         <button class="btn">Restaurar por defecto</button>
     </div>
+
+    <div class="card">
+        <h3 style="margin:0 0 8px 0; font-size:15px">Cuenta</h3>
+        <button class="btn" type="button" (click)="linkGoogle()">Conectar con Google</button>
+    </div>
 </section>

--- a/Frontend/src/app/features/dashboard/preferences/preferences.component.ts
+++ b/Frontend/src/app/features/dashboard/preferences/preferences.component.ts
@@ -1,5 +1,8 @@
-import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { CommonModule } from "@angular/common";
+
+import { AuthService } from "../../../core/auth/auth.service";
+import { GoogleAuthService } from "../../../core/auth/google-auth.service";
 
 @Component({
   selector: "app-preferences",
@@ -9,4 +12,13 @@ import { CommonModule } from "@angular/common";
   styleUrl: "./preferences.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class PreferencesComponent {}
+export class PreferencesComponent {
+  private readonly authService = inject(AuthService);
+  private readonly googleAuth = inject(GoogleAuthService);
+
+  linkGoogle(): void {
+    this.googleAuth.signIn().then((idToken) => {
+      this.authService.linkGoogleAccount(idToken).subscribe();
+    });
+  }
+}

--- a/Frontend/src/environments/environment.prod.ts
+++ b/Frontend/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
   apiUrl: "https://tu-api-produccion.com/api/v1", // Cambia esto por tu URL de producción
+  googleClientId: "GOOGLE_CLIENT_ID",
 };

--- a/Frontend/src/environments/environment.ts
+++ b/Frontend/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: "http://localhost:3000/api/v1",
+  googleClientId: "GOOGLE_CLIENT_ID",
 };

--- a/Frontend/src/index.html
+++ b/Frontend/src/index.html
@@ -12,6 +12,7 @@
   <link
     href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@600;700&display=swap"
     rel="stylesheet">
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- add Google Identity script and service
- allow logging in with Google and linking existing accounts
- expose googleClientId in environments

## Testing
- `npm ci`
- `npm run build`
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform, attempted installation)*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_6896bccfd4a48326a8221c538a2eff49