### PR TITLE
feat: add backend google oauth flow

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -3,5 +3,5 @@ MONGODB_URI=mongodb://localhost:27017/nidify
 JWT_SECRET=changeme
 JWT_REFRESH_SECRET=changeme-refresh
 GOOGLE_CLIENT_ID=
-EXCHANGE_RATE_API_BASE=https://api.exchangerate.host
-EXCHANGE_RATE_TTL_MINUTES=60
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=http://localhost:3000/api/v1/auth/google/callback

--- a/Backend/src/application/use-cases/oauth-login.usecase.ts
+++ b/Backend/src/application/use-cases/oauth-login.usecase.ts
@@ -1,0 +1,40 @@
+import { UserRepository } from '../../infrastructure/persistence/repositories/user.repository';
+import { OAuthProvider } from '../../infrastructure/auth/oauth-provider.interface';
+import { User } from '../../domain/models/user.model';
+import { UserStatus } from '../../domain/models/enums/user-status.enum';
+
+export class OAuthLoginUseCase {
+  constructor(
+    private userRepository: UserRepository,
+    private provider: OAuthProvider,
+  ) {}
+
+  async execute(code: string): Promise<{ user: User }> {
+    const profile = await this.provider.getUserProfile(code);
+    const { externalId, email, fullName } = profile;
+    let user = await this.userRepository.findByEmail(email);
+    if (!user) {
+      user = await this.userRepository.create({
+        fullName,
+        email,
+        oauthProviders: [
+          { provider: this.provider.name, externalId, linkedAt: new Date() },
+        ],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        status: UserStatus.ACTIVE,
+      });
+    } else if (
+      !user.oauthProviders.some((p) => p.provider === this.provider.name)
+    ) {
+      await this.userRepository.update(user.id, {
+        oauthProviders: [
+          ...user.oauthProviders,
+          { provider: this.provider.name, externalId, linkedAt: new Date() },
+        ],
+      });
+      user = (await this.userRepository.findById(user.id))!;
+    }
+    return { user };
+  }
+}

--- a/Backend/src/config/env.ts
+++ b/Backend/src/config/env.ts
@@ -9,6 +9,10 @@ export const config = {
   jwtSecret: process.env.JWT_SECRET ?? 'changeme',
   jwtRefreshSecret: process.env.JWT_REFRESH_SECRET ?? 'changeme-refresh',
   googleClientId: process.env.GOOGLE_CLIENT_ID ?? '',
+  googleClientSecret: process.env.GOOGLE_CLIENT_SECRET ?? '',
+  googleRedirectUri:
+    process.env.GOOGLE_REDIRECT_URI ??
+    'http://localhost:3000/api/v1/auth/google/callback',
   exchangeRateApiBase:
     process.env.EXCHANGE_RATE_API_BASE ?? 'https://api.exchangerate.host',
   exchangeRateTtlMinutes: Number(process.env.EXCHANGE_RATE_TTL_MINUTES ?? 60),

--- a/Backend/src/infrastructure/auth/google-oauth.provider.ts
+++ b/Backend/src/infrastructure/auth/google-oauth.provider.ts
@@ -1,0 +1,44 @@
+import { OAuth2Client } from 'google-auth-library';
+import { OAuthProvider, OAuthUserProfile } from './oauth-provider.interface';
+import { config } from '../../config/env';
+import { UnauthorizedError } from '../../domain/errors/unauthorized.error';
+
+export class GoogleOAuthProvider implements OAuthProvider {
+  name = 'google';
+  private client: OAuth2Client;
+
+  constructor() {
+    this.client = new OAuth2Client(
+      config.googleClientId,
+      config.googleClientSecret,
+      config.googleRedirectUri,
+    );
+  }
+
+  getAuthorizationUrl(): string {
+    return this.client.generateAuthUrl({
+      scope: ['profile', 'email'],
+      redirect_uri: config.googleRedirectUri,
+      access_type: 'offline',
+      prompt: 'consent',
+    });
+  }
+
+  async getUserProfile(code: string): Promise<OAuthUserProfile> {
+    const { tokens } = await this.client.getToken(code);
+    const idToken = tokens.id_token;
+    if (!idToken) {
+      throw new UnauthorizedError('Token de Google inválido');
+    }
+    const ticket = await this.client.verifyIdToken({ idToken });
+    const payload = ticket.getPayload();
+    if (!payload?.sub || !payload.email || !payload.name) {
+      throw new UnauthorizedError('Token de Google inválido');
+    }
+    return {
+      externalId: payload.sub,
+      email: payload.email,
+      fullName: payload.name,
+    };
+  }
+}

--- a/Backend/src/infrastructure/auth/oauth-provider.interface.ts
+++ b/Backend/src/infrastructure/auth/oauth-provider.interface.ts
@@ -1,0 +1,11 @@
+export interface OAuthUserProfile {
+  externalId: string;
+  email: string;
+  fullName: string;
+}
+
+export interface OAuthProvider {
+  name: string;
+  getAuthorizationUrl(): string;
+  getUserProfile(code: string): Promise<OAuthUserProfile>;
+}

--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -18,6 +18,13 @@ export const routes: Routes = [
       ),
   },
   {
+    path: "auth/google/callback",
+    loadComponent: () =>
+      import("./features/auth/google-callback/google-callback.component").then(
+        (m) => m.GoogleCallbackComponent
+      ),
+  },
+  {
     path: "onboarding",
     loadComponent: () =>
       import("./features/onboarding/onboarding.component").then(

--- a/Frontend/src/app/core/auth/auth.service.spec.ts
+++ b/Frontend/src/app/core/auth/auth.service.spec.ts
@@ -43,10 +43,11 @@ describe("AuthService", () => {
     expect(localStorage.getItem("accessToken")).toBeNull();
   });
 
-  it("stores session on google login", () => {
-    service.loginWithGoogle("token123").subscribe();
-    const req = httpMock.expectOne("/auth/google");
-    expect(req.request.body).toEqual({ idToken: "token123" });
+  it("stores session on oauth login", () => {
+    service.oauthLogin("code123").subscribe();
+    const req = httpMock.expectOne((r) => r.url === "/auth/google/callback");
+    expect(req.request.params.get("code")).toBe("code123");
+    expect(req.request.method).toBe("GET");
     expect(req.request.withCredentials).toBeTrue();
     req.flush({
       user: {

--- a/Frontend/src/app/core/auth/auth.service.ts
+++ b/Frontend/src/app/core/auth/auth.service.ts
@@ -89,13 +89,12 @@ export class AuthService {
       .pipe(tap((res) => this.storeSession(res)));
   }
 
-  loginWithGoogle(idToken: string) {
+  oauthLogin(code: string) {
     return this.http
-      .post<AuthResponse>(
-        "/auth/google",
-        { idToken },
-        { withCredentials: true }
-      )
+      .get<AuthResponse>("/auth/google/callback", {
+        params: { code },
+        withCredentials: true,
+      })
       .pipe(tap((res) => this.storeSession(res)));
   }
 

--- a/Frontend/src/app/features/auth/google-callback/google-callback.component.ts
+++ b/Frontend/src/app/features/auth/google-callback/google-callback.component.ts
@@ -1,0 +1,39 @@
+import { CommonModule } from "@angular/common";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  inject,
+} from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+
+import { AuthService } from "../../../core/auth/auth.service";
+
+@Component({
+  selector: "app-google-callback",
+  standalone: true,
+  imports: [CommonModule],
+  template: `<p>Procesando autenticación...</p>`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class GoogleCallbackComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+
+  ngOnInit(): void {
+    const code = this.route.snapshot.queryParamMap.get("code");
+    if (!code) {
+      this.router.navigate(["/login"]);
+      return;
+    }
+    this.authService.oauthLogin(code).subscribe({
+      next: () => this.router.navigate(["/home"]),
+      error: (err) => {
+        console.error("OAuth login failed", err);
+        this.router.navigate(["/login"]);
+      },
+    });
+  }
+}
+

--- a/Frontend/src/app/features/auth/login/login.component.ts
+++ b/Frontend/src/app/features/auth/login/login.component.ts
@@ -4,8 +4,8 @@ import { Router, RouterLink } from "@angular/router";
 import { CommonModule } from "@angular/common";
 
 import { AuthService } from "../../../core/auth/auth.service";
-import { GoogleAuthService } from "../../../core/auth/google-auth.service";
 import { ProblemInlineComponent } from "../../../shared/components/problem-inline/problem-inline.component";
+import { environment } from "../../../../environments/environment";
 
 @Component({
   selector: "app-login",
@@ -23,7 +23,6 @@ import { ProblemInlineComponent } from "../../../shared/components/problem-inlin
 export class LoginComponent {
   private readonly fb = inject(FormBuilder);
   private readonly authService = inject(AuthService);
-  private readonly googleAuth = inject(GoogleAuthService);
   private readonly router = inject(Router);
 
   readonly form = this.fb.nonNullable.group({
@@ -45,27 +44,7 @@ export class LoginComponent {
   }
 
   googleLogin(): void {
-    this.googleAuth
-      .signIn()
-      .then((idToken) => {
-        this.authService.loginWithGoogle(idToken).subscribe({
-          next: () => {
-            this.router.navigate(["/home"]);
-          },
-          error: (error) => {
-            console.error("Error al autenticar con Google:", error);
-            // Aquí puedes agregar una notificación de error al usuario
-          },
-        });
-      })
-      .catch((error) => {
-        console.error("Error en Google Sign-In:", error);
-        // Manejo específico de errores de Google OAuth
-        if (error.includes("dominio")) {
-          console.warn(
-            "⚠️ Configuración requerida: Añade localhost:4200 a los dominios autorizados en Google Cloud Console"
-          );
-        }
-      });
+    window.location.href = `${environment.apiUrl}/auth/google`;
   }
 }
+


### PR DESCRIPTION
## Summary
- redirect login to backend-managed Google OAuth
- add callback component and service method to complete OAuth login
- register OAuth callback route and update tests

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless requires snap install)*
- `npm run lint` *(fails: missing script "lint")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897656ac5408326a22c40d17fc4bd7b