### PR TITLE
Handle OAuth callback redirect

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -5,3 +5,4 @@ JWT_REFRESH_SECRET=changeme-refresh
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:3000/api/v1/auth/google/callback
+FRONTEND_REDIRECT_URI=http://localhost:4200/auth/google/callback

--- a/Backend/src/config/env.ts
+++ b/Backend/src/config/env.ts
@@ -13,6 +13,9 @@ export const config = {
   googleRedirectUri:
     process.env.GOOGLE_REDIRECT_URI ??
     'http://localhost:3000/api/v1/auth/google/callback',
+  frontendRedirectUri:
+    process.env.FRONTEND_REDIRECT_URI ??
+    'http://localhost:4200/auth/google/callback',
   exchangeRateApiBase:
     process.env.EXCHANGE_RATE_API_BASE ?? 'https://api.exchangerate.host',
   exchangeRateTtlMinutes: Number(process.env.EXCHANGE_RATE_TTL_MINUTES ?? 60),

--- a/Frontend/src/app/core/auth/auth.service.spec.ts
+++ b/Frontend/src/app/core/auth/auth.service.spec.ts
@@ -61,6 +61,18 @@ describe("AuthService", () => {
     expect(service.getToken()).toBe("gToken");
   });
 
+  it("stores session from oauth redirect", () => {
+    const user = {
+      id: "1",
+      fullName: "Test User",
+      email: "test@example.com",
+      roles: ["user"],
+    };
+    service.completeOAuthLogin(user, "cbToken");
+    expect(service.getToken()).toBe("cbToken");
+    expect(localStorage.getItem("user")).toContain("Test User");
+  });
+
   it("updates user on google account link", () => {
     service.linkGoogleAccount("idTok").subscribe();
     const req = httpMock.expectOne("/auth/google/link");

--- a/Frontend/src/app/core/auth/auth.service.ts
+++ b/Frontend/src/app/core/auth/auth.service.ts
@@ -98,6 +98,10 @@ export class AuthService {
       .pipe(tap((res) => this.storeSession(res)));
   }
 
+  completeOAuthLogin(user: User, accessToken: string): void {
+    this.storeSession({ user, accessToken });
+  }
+
   register(fullName: string, email: string, password: string) {
     const body: RegisterRequest = { fullName, email, password };
     return this.http

--- a/Frontend/src/app/features/auth/google-callback/google-callback.component.ts
+++ b/Frontend/src/app/features/auth/google-callback/google-callback.component.ts
@@ -8,6 +8,7 @@ import {
 import { ActivatedRoute, Router } from "@angular/router";
 
 import { AuthService } from "../../../core/auth/auth.service";
+import { User } from "../../../core/auth/user.model";
 
 @Component({
   selector: "app-google-callback",
@@ -22,18 +23,23 @@ export class GoogleCallbackComponent implements OnInit {
   private readonly router = inject(Router);
 
   ngOnInit(): void {
-    const code = this.route.snapshot.queryParamMap.get("code");
-    if (!code) {
+    const token = this.route.snapshot.queryParamMap.get("token");
+    const userParam = this.route.snapshot.queryParamMap.get("user");
+    const error = this.route.snapshot.queryParamMap.get("error");
+
+    if (error || !token || !userParam) {
       this.router.navigate(["/login"]);
       return;
     }
-    this.authService.oauthLogin(code).subscribe({
-      next: () => this.router.navigate(["/home"]),
-      error: (err) => {
-        console.error("OAuth login failed", err);
-        this.router.navigate(["/login"]);
-      },
-    });
+
+    try {
+      const user: User = JSON.parse(decodeURIComponent(userParam));
+      this.authService.completeOAuthLogin(user, token);
+      this.router.navigate(["/home"]);
+    } catch (err) {
+      console.error("OAuth login failed", err);
+      this.router.navigate(["/login"]);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add frontend redirect URL configuration and robust Google OAuth callback handler
- Support storing OAuth session after backend redirect in frontend
- Document frontend callback environment variable

## Testing
- `cd Backend && npm test`
- `cd Backend && npm run lint`
- `cd Backend && npm run build`
- `cd Frontend && npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*
- `cd Frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68977a4bdbcc8326a574cb3ecfc7b1f6