### PR TITLE
Set default currency from user location with override option

### DIFF
--- a/Backend/src/application/use-cases/register-user.usecase.ts
+++ b/Backend/src/application/use-cases/register-user.usecase.ts
@@ -11,6 +11,7 @@ export class RegisterUserUseCase {
     fullName: string,
     email: string,
     password: string,
+    preferredCurrency?: string,
   ): Promise<User> {
     const existing = await this.userRepository.findByEmail(email);
     if (existing) {
@@ -25,6 +26,7 @@ export class RegisterUserUseCase {
       createdAt: new Date(),
       updatedAt: new Date(),
       status: UserStatus.ACTIVE,
+      ...(preferredCurrency ? { preferredCurrency } : {}),
     });
     return user;
   }

--- a/Backend/src/application/use-cases/update-preferred-currency.usecase.ts
+++ b/Backend/src/application/use-cases/update-preferred-currency.usecase.ts
@@ -1,0 +1,18 @@
+import { UserRepository } from '../../infrastructure/persistence/repositories/user.repository';
+import { User } from '../../domain/models/user.model';
+import { NotFoundError } from '../../domain/errors/not-found.error';
+
+export class UpdatePreferredCurrencyUseCase {
+  constructor(private userRepository: UserRepository) {}
+
+  async execute(userId: string, currency: string): Promise<User> {
+    const user = await this.userRepository.update(userId, {
+      preferredCurrency: currency,
+      updatedAt: new Date(),
+    });
+    if (!user) {
+      throw new NotFoundError('Usuario no encontrado');
+    }
+    return user;
+  }
+}

--- a/Backend/src/infrastructure/location/geo-ip.service.ts
+++ b/Backend/src/infrastructure/location/geo-ip.service.ts
@@ -1,0 +1,17 @@
+export class GeoIpService {
+  async getCurrency(ip?: string): Promise<string | null> {
+    try {
+      const url = ip
+        ? `https://ipapi.co/${ip}/json/`
+        : 'https://ipapi.co/json/';
+      const res = await fetch(url);
+      if (!res.ok) {
+        return null;
+      }
+      const data = (await res.json()) as { currency?: string };
+      return data.currency ?? null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/Backend/src/interfaces/http/controllers/user-preferences.controller.ts
+++ b/Backend/src/interfaces/http/controllers/user-preferences.controller.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from 'express';
+import { UpdatePreferredCurrencyUseCase } from '../../../application/use-cases/update-preferred-currency.usecase';
+import { CurrencyPreferenceDto } from '../dto/currency-preference.dto';
+import { toPublicUser } from '../dto/user.dto';
+
+interface AuthRequest extends Request {
+  userId: string;
+}
+
+export class UserPreferencesController {
+  constructor(
+    private updatePreferredCurrency: UpdatePreferredCurrencyUseCase,
+  ) {}
+
+  updateCurrency = async (req: Request, res: Response) => {
+    const { currency } = req.body as CurrencyPreferenceDto;
+    const user = await this.updatePreferredCurrency.execute(
+      (req as AuthRequest).userId,
+      currency,
+    );
+    res.json({ user: toPublicUser(user) });
+  };
+}

--- a/Backend/src/interfaces/http/dto/auth.dto.ts
+++ b/Backend/src/interfaces/http/dto/auth.dto.ts
@@ -4,6 +4,7 @@ export const registerSchema = z.object({
   fullName: z.string().min(1),
   email: z.string().email(),
   password: z.string().min(6),
+  preferredCurrency: z.string().length(3).optional(),
 });
 export type RegisterRequestDto = z.infer<typeof registerSchema>;
 

--- a/Backend/src/interfaces/http/dto/currency-preference.dto.ts
+++ b/Backend/src/interfaces/http/dto/currency-preference.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const currencyPreferenceSchema = z.object({
+  currency: z.string().length(3),
+});
+
+export type CurrencyPreferenceDto = z.infer<typeof currencyPreferenceSchema>;

--- a/Backend/src/interfaces/http/dto/user.dto.ts
+++ b/Backend/src/interfaces/http/dto/user.dto.ts
@@ -5,14 +5,19 @@ export interface PublicUserDto {
   fullName: string;
   email: string;
   roles: string[];
+  preferredCurrency?: string;
 }
 
 export function toPublicUser(user: User): PublicUserDto {
-  return {
+  const dto: PublicUserDto = {
     id: user.id,
     fullName: user.fullName,
     email: user.email,
     // Roles no forman parte del dominio de usuario todavía; exponer como lista vacía por defecto
     roles: [],
   };
+  if (user.preferredCurrency) {
+    dto.preferredCurrency = user.preferredCurrency;
+  }
+  return dto;
 }

--- a/Backend/src/interfaces/http/routes/auth.routes.ts
+++ b/Backend/src/interfaces/http/routes/auth.routes.ts
@@ -14,6 +14,7 @@ import { OAuth2Client } from 'google-auth-library';
 import { config } from '../../../config/env';
 import { GoogleOAuthProvider } from '../../../infrastructure/auth/google-oauth.provider';
 import { OAuthLoginUseCase } from '../../../application/use-cases/oauth-login.usecase';
+import { GeoIpService } from '../../../infrastructure/location/geo-ip.service';
 import { authMiddleware } from '../../middleware/auth.middleware';
 import { validate } from '../../middleware/validation.middleware';
 import { registerSchema, loginSchema, googleSchema } from '../dto/auth.dto';
@@ -30,6 +31,7 @@ const refreshTokenService = new RefreshTokenService(
 );
 const googleClient = new OAuth2Client(config.googleClientId);
 const googleOAuthProvider = new GoogleOAuthProvider();
+const geoIpService = new GeoIpService();
 
 const registerUser = new RegisterUserUseCase(userRepository);
 const loginUser = new LoginUserUseCase(userRepository);
@@ -47,6 +49,7 @@ const controller = new AuthController(
   refreshTokenService,
   googleOAuthProvider,
   oauthLogin,
+  geoIpService,
 );
 
 router.post(

--- a/Backend/src/interfaces/http/routes/user.routes.ts
+++ b/Backend/src/interfaces/http/routes/user.routes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { UserPreferencesController } from '../controllers/user-preferences.controller';
+import { UserRepository } from '../../../infrastructure/persistence/repositories/user.repository';
+import { UpdatePreferredCurrencyUseCase } from '../../../application/use-cases/update-preferred-currency.usecase';
+import { authMiddleware } from '../../middleware/auth.middleware';
+import { JwtService } from '../../../infrastructure/auth/jwt.service';
+import { validate } from '../../middleware/validation.middleware';
+import { currencyPreferenceSchema } from '../dto/currency-preference.dto';
+
+const router = Router();
+const userRepository = new UserRepository();
+const updatePreferredCurrency = new UpdatePreferredCurrencyUseCase(
+  userRepository,
+);
+const jwtService = new JwtService();
+const controller = new UserPreferencesController(updatePreferredCurrency);
+
+router.patch(
+  '/me/currency',
+  authMiddleware(jwtService),
+  validate({ body: currencyPreferenceSchema }),
+  controller.updateCurrency,
+);
+
+export default router;

--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -13,6 +13,7 @@ import currencyRoutes from './interfaces/http/routes/currency.routes';
 import changelogRoutes from './interfaces/http/routes/changelog.routes';
 import preferencesRoutes from './interfaces/http/routes/notification-preferences.routes';
 import alertRoutes from './interfaces/http/routes/alert.routes';
+import userRoutes from './interfaces/http/routes/user.routes';
 import { initSocket } from './infrastructure/websocket/socket.service';
 import './infrastructure/events/changelog.subscriber';
 import './infrastructure/events/alerts.subscriber';
@@ -44,6 +45,7 @@ app.use('/api/v1/households/:householdId/changelog', changelogRoutes);
 app.use('/api/v1/households/:householdId/preferences', preferencesRoutes);
 app.use('/api/v1/households/:householdId/alerts', alertRoutes);
 app.use('/api/v1/currency', currencyRoutes);
+app.use('/api/v1/users', userRoutes);
 
 app.get('/', (_req, res) => {
   res.send('API de Nidify');

--- a/Frontend/src/app/core/auth/auth.service.ts
+++ b/Frontend/src/app/core/auth/auth.service.ts
@@ -25,6 +25,7 @@ interface RegisterRequest {
   fullName: string;
   email: string;
   password: string;
+  preferredCurrency?: string;
 }
 
 interface AuthResponse {
@@ -102,11 +103,36 @@ export class AuthService {
     this.storeSession({ user, accessToken });
   }
 
-  register(fullName: string, email: string, password: string) {
-    const body: RegisterRequest = { fullName, email, password };
+  register(
+    fullName: string,
+    email: string,
+    password: string,
+    preferredCurrency?: string,
+  ) {
+    const body: RegisterRequest = {
+      fullName,
+      email,
+      password,
+      preferredCurrency,
+    };
     return this.http
       .post<AuthResponse>("/auth/register", body, { withCredentials: true })
       .pipe(tap((res) => this.storeSession(res)));
+  }
+
+  updatePreferredCurrency(currency: string) {
+    return this.http
+      .patch<{ user: User }>(
+        "/users/me/currency",
+        { currency },
+        { withCredentials: true }
+      )
+      .pipe(
+        tap(({ user }) => {
+          localStorage.setItem("user", JSON.stringify(user));
+          this.userSubject.next(user);
+        })
+      );
   }
 
   linkGoogleAccount(idToken: string) {

--- a/Frontend/src/app/core/auth/user.model.ts
+++ b/Frontend/src/app/core/auth/user.model.ts
@@ -3,4 +3,5 @@ export interface User {
   fullName: string;
   email: string;
   roles: string[];
+  preferredCurrency?: string;
 }

--- a/Frontend/src/app/core/geo/geo.service.ts
+++ b/Frontend/src/app/core/geo/geo.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class GeoService {
+  async getCurrency(): Promise<string | null> {
+    try {
+      const res = await fetch('https://ipapi.co/json/');
+      if (!res.ok) {
+        return null;
+      }
+      const data = (await res.json()) as { currency?: string };
+      return data.currency ?? null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/Frontend/src/app/features/auth/register/register.component.ts
+++ b/Frontend/src/app/features/auth/register/register.component.ts
@@ -5,6 +5,7 @@ import { CommonModule } from "@angular/common";
 
 import { AuthService } from "../../../core/auth/auth.service";
 import { ProblemInlineComponent } from "../../../shared/components/problem-inline/problem-inline.component";
+import { GeoService } from "../../../core/geo/geo.service";
 
 @Component({
   selector: "app-register",
@@ -23,6 +24,7 @@ export class RegisterComponent {
   private readonly fb = inject(FormBuilder);
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
+  private readonly geo = inject(GeoService);
 
   readonly form = this.fb.nonNullable.group({
     fullName: ["", Validators.required],
@@ -36,10 +38,14 @@ export class RegisterComponent {
       return;
     }
     const { fullName, email, password } = this.form.getRawValue();
-    this.authService.register(fullName, email, password).subscribe({
-      next: () => {
-        this.router.navigate(["/home"]);
-      },
+    this.geo.getCurrency().then((currency) => {
+      this.authService
+        .register(fullName, email, password, currency ?? undefined)
+        .subscribe({
+          next: () => {
+            this.router.navigate(["/home"]);
+          },
+        });
     });
   }
 }

--- a/Frontend/src/app/features/dashboard/preferences/preferences.component.html
+++ b/Frontend/src/app/features/dashboard/preferences/preferences.component.html
@@ -11,11 +11,8 @@
         <div class="form-grid">
             <label class="field">
                 <span class="label">Moneda preferida</span>
-                <select class="input">
-                    <option>USD</option>
-                    <option>EUR</option>
-                    <option>ARS</option>
-                    <option>MXN</option>
+                <select class="input" [(ngModel)]="selectedCurrency">
+                    <option *ngFor="let c of currencies" [value]="c">{{ c }}</option>
                 </select>
             </label>
             <label class="field">
@@ -28,7 +25,7 @@
                 </select>
             </label>
         </div>
-        <button class="btn primary" style="margin-top:10px">Guardar</button>
+        <button class="btn primary" style="margin-top:10px" (click)="save()">Guardar</button>
     </div>
 
     <div class="card">

--- a/Frontend/src/app/features/dashboard/preferences/preferences.component.ts
+++ b/Frontend/src/app/features/dashboard/preferences/preferences.component.ts
@@ -1,13 +1,16 @@
 import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { CommonModule } from "@angular/common";
+import { FormsModule } from "@angular/forms";
 
 import { AuthService } from "../../../core/auth/auth.service";
 import { GoogleAuthService } from "../../../core/auth/google-auth.service";
+import { GeoService } from "../../../core/geo/geo.service";
+import { take } from "rxjs";
 
 @Component({
   selector: "app-preferences",
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   templateUrl: "./preferences.component.html",
   styleUrl: "./preferences.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -15,10 +18,34 @@ import { GoogleAuthService } from "../../../core/auth/google-auth.service";
 export class PreferencesComponent {
   private readonly authService = inject(AuthService);
   private readonly googleAuth = inject(GoogleAuthService);
+  private readonly geo = inject(GeoService);
+
+  currencies = ["USD", "EUR", "ARS", "MXN"];
+  selectedCurrency = this.currencies[0];
+
+  constructor() {
+    this.authService.user$.pipe(take(1)).subscribe((user) => {
+      if (user?.preferredCurrency) {
+        this.selectedCurrency = user.preferredCurrency;
+      } else {
+        this.geo.getCurrency().then((curr) => {
+          if (curr) {
+            this.selectedCurrency = curr;
+          }
+        });
+      }
+    });
+  }
 
   linkGoogle(): void {
     this.googleAuth.signIn().then((idToken) => {
       this.authService.linkGoogleAccount(idToken).subscribe();
     });
+  }
+
+  save(): void {
+    this.authService
+      .updatePreferredCurrency(this.selectedCurrency)
+      .subscribe();
   }
 }


### PR DESCRIPTION
## Summary
- infer default currency from user location on registration
- allow users to update preferred currency in settings
- expose currency preference to frontend and persist changes

## Testing
- `cd Backend && npm test`
- `cd Backend && npm run lint`
- `cd Backend && npm run build`
- `cd Frontend && npm test` (fails: No binary for Chrome browser)
- `cd Frontend && npm run lint` (fails: Missing script: "lint")
- `cd Frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897abef2d688326ac5e10f98af0a591