### PR TITLE
feat(frontend): allow switching households

### DIFF
--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -1,9 +1,12 @@
 <div class="app-shell">
     <header class="topbar">
         <div class="topbar__title">Nidify</div>
-        <button class="topbar__action" (click)="logout()" aria-label="Cerrar sesión">
-            ⎋
-        </button>
+        <div class="topbar__actions">
+            <app-household-switcher></app-household-switcher>
+            <button class="topbar__action" (click)="logout()" aria-label="Cerrar sesión">
+                ⎋
+            </button>
+        </div>
     </header>
 
     <main class="content">

--- a/Frontend/src/app/features/home/home.component.scss
+++ b/Frontend/src/app/features/home/home.component.scss
@@ -24,6 +24,12 @@
   color: var(--base-00);
 }
 
+.topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
 .topbar__action {
   appearance: none;
   border: 0;

--- a/Frontend/src/app/features/home/home.component.ts
+++ b/Frontend/src/app/features/home/home.component.ts
@@ -1,13 +1,14 @@
 import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { RouterLink, RouterLinkActive, RouterOutlet } from "@angular/router";
+import { HouseholdSwitcherComponent } from "./household-switcher.component";
 
 import { AuthService } from "../../core/auth/auth.service";
 
 @Component({
   selector: "app-home",
   standalone: true,
-  imports: [CommonModule, RouterOutlet, RouterLink, RouterLinkActive],
+  imports: [CommonModule, RouterOutlet, RouterLink, RouterLinkActive, HouseholdSwitcherComponent],
   templateUrl: "./home.component.html",
   styleUrl: "./home.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/Frontend/src/app/features/home/household-switcher.component.html
+++ b/Frontend/src/app/features/home/household-switcher.component.html
@@ -1,0 +1,15 @@
+<ng-container *ngIf="(households$ | async) as households">
+  <ng-container *ngIf="households.length > 1; else singleHousehold">
+    <select
+      class="household-select"
+      [value]="(householdId$ | async) ?? ''"
+      (change)="onSelect($any($event.target).value)"
+      aria-label="Seleccionar hogar"
+    >
+      <option *ngFor="let h of households" [value]="h.id">{{ h.name }}</option>
+    </select>
+  </ng-container>
+  <ng-template #singleHousehold>
+    <span class="household-name">{{ households[0]?.name }}</span>
+  </ng-template>
+</ng-container>

--- a/Frontend/src/app/features/home/household-switcher.component.scss
+++ b/Frontend/src/app/features/home/household-switcher.component.scss
@@ -1,0 +1,15 @@
+:host {
+  display: block;
+}
+
+.household-select {
+  padding: 4px 8px;
+  border: 1px solid var(--base-80);
+  border-radius: var(--radius-md);
+  background: var(--white);
+  color: var(--base-20);
+}
+
+.household-name {
+  font-weight: 500;
+}

--- a/Frontend/src/app/features/home/household-switcher.component.spec.ts
+++ b/Frontend/src/app/features/home/household-switcher.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+import { HouseholdSwitcherComponent } from './household-switcher.component';
+
+describe('HouseholdSwitcherComponent', () => {
+  let component: HouseholdSwitcherComponent;
+  let fixture: ComponentFixture<HouseholdSwitcherComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HouseholdSwitcherComponent, HttpClientTestingModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HouseholdSwitcherComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Frontend/src/app/features/home/household-switcher.component.ts
+++ b/Frontend/src/app/features/home/household-switcher.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { HouseholdService } from "../../core/household/household.service";
+
+@Component({
+  selector: "app-household-switcher",
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: "./household-switcher.component.html",
+  styleUrl: "./household-switcher.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HouseholdSwitcherComponent {
+  private readonly householdService = inject(HouseholdService);
+  readonly households$ = this.householdService.getUserHouseholds();
+  readonly householdId$ = this.householdService.householdId$;
+
+  onSelect(id: string): void {
+    this.householdService.selectHousehold(id);
+  }
+}


### PR DESCRIPTION
## Summary
- add household switcher component and styles
- expose household listing and selector in service
- integrate switcher into home topbar

## Testing
- `npm ci`
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6897ed8cdc1883268fe2e12288dac5fa