### PR TITLE
Add household retrieval endpoint

### DIFF
--- a/Backend/src/application/__tests__/get-household.usecase.spec.ts
+++ b/Backend/src/application/__tests__/get-household.usecase.spec.ts
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { HouseholdRepository } from '../../infrastructure/persistence/repositories/household.repository';
+import { GetHouseholdUseCase } from '../use-cases/get-household.usecase';
+
+describe('GetHouseholdUseCase', () => {
+  let mongo: MongoMemoryServer;
+  let repo: HouseholdRepository;
+  let getHousehold: GetHouseholdUseCase;
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create();
+    await mongoose.connect(mongo.getUri());
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongo.stop();
+  });
+
+  beforeEach(async () => {
+    await mongoose.connection.db.dropDatabase();
+    repo = new HouseholdRepository();
+    getHousehold = new GetHouseholdUseCase(repo);
+  });
+
+  it('returns household by id', async () => {
+    const created = await repo.create({
+      name: 'Test',
+      baseCurrency: 'USD',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const found = await getHousehold.execute(created.id);
+    expect(found).toBeTruthy();
+    expect(found?.id).toBe(created.id);
+  });
+});

--- a/Backend/src/application/use-cases/get-household.usecase.ts
+++ b/Backend/src/application/use-cases/get-household.usecase.ts
@@ -1,0 +1,10 @@
+import { Household } from '../../domain/models/household.model';
+import { HouseholdRepository } from '../../infrastructure/persistence/repositories/household.repository';
+
+export class GetHouseholdUseCase {
+  constructor(private householdRepo: HouseholdRepository) {}
+
+  async execute(id: string): Promise<Household | null> {
+    return this.householdRepo.findById(id);
+  }
+}

--- a/Backend/src/infrastructure/persistence/repositories/household.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/household.repository.ts
@@ -8,7 +8,10 @@ export class HouseholdRepository {
   }
 
   async findById(id: string): Promise<Household | null> {
-    return (await HouseholdModel.findById(id).lean()) as Household | null;
+    const found = await HouseholdModel.findById(id).lean();
+    return found
+      ? ({ id: found._id.toString(), ...found } as unknown as Household)
+      : null;
   }
 
   async update(
@@ -18,6 +21,8 @@ export class HouseholdRepository {
     const updated = await HouseholdModel.findByIdAndUpdate(id, update, {
       new: true,
     }).lean();
-    return updated as Household | null;
+    return updated
+      ? ({ id: updated._id.toString(), ...updated } as unknown as Household)
+      : null;
   }
 }

--- a/Backend/src/interfaces/http/controllers/household.controller.ts
+++ b/Backend/src/interfaces/http/controllers/household.controller.ts
@@ -3,6 +3,8 @@ import { CreateHouseholdUseCase } from '../../../application/use-cases/create-ho
 import { InviteToHouseholdUseCase } from '../../../application/use-cases/invite-to-household.usecase';
 import { RevokeMembershipUseCase } from '../../../application/use-cases/revoke-membership.usecase';
 import { CancelInvitationUseCase } from '../../../application/use-cases/cancel-invitation.usecase';
+import { GetHouseholdUseCase } from '../../../application/use-cases/get-household.usecase';
+import { NotFoundError } from '../../../domain/errors/not-found.error';
 import {
   CreateHouseholdRequestDto,
   InviteRequestDto,
@@ -18,6 +20,7 @@ export class HouseholdController {
     private inviteToHousehold: InviteToHouseholdUseCase,
     private revokeMembership: RevokeMembershipUseCase,
     private cancelInvitationUseCase: CancelInvitationUseCase,
+    private getHousehold: GetHouseholdUseCase,
   ) {}
 
   create = async (req: Request, res: Response) => {
@@ -65,5 +68,14 @@ export class HouseholdController {
       invitationId,
     );
     res.status(204).send();
+  };
+
+  get = async (req: Request, res: Response) => {
+    const { householdId } = req.params as { householdId: string };
+    const household = await this.getHousehold.execute(householdId);
+    if (!household) {
+      throw new NotFoundError('Household not found');
+    }
+    res.json({ household });
   };
 }

--- a/Backend/src/interfaces/http/routes/household.routes.ts
+++ b/Backend/src/interfaces/http/routes/household.routes.ts
@@ -10,6 +10,7 @@ import { CreateHouseholdUseCase } from '../../../application/use-cases/create-ho
 import { InviteToHouseholdUseCase } from '../../../application/use-cases/invite-to-household.usecase';
 import { RevokeMembershipUseCase } from '../../../application/use-cases/revoke-membership.usecase';
 import { CancelInvitationUseCase } from '../../../application/use-cases/cancel-invitation.usecase';
+import { GetHouseholdUseCase } from '../../../application/use-cases/get-household.usecase';
 import { EmailService } from '../../../infrastructure/notifications/email.service';
 import { validate } from '../../middleware/validation.middleware';
 import { createHouseholdSchema, inviteSchema } from '../dto/household.dto';
@@ -39,12 +40,14 @@ const cancelInvitation = new CancelInvitationUseCase(
   invitationRepo,
   userRepo,
 );
+const getHousehold = new GetHouseholdUseCase(householdRepo);
 
 const controller = new HouseholdController(
   createHousehold,
   inviteToHousehold,
   revokeMembership,
   cancelInvitation,
+  getHousehold,
 );
 
 router.post(
@@ -53,6 +56,7 @@ router.post(
   validate({ body: createHouseholdSchema }),
   controller.create,
 );
+router.get('/:householdId', authMiddleware(jwtService), controller.get);
 router.post(
   '/:householdId/invitations',
   authMiddleware(jwtService),


### PR DESCRIPTION
## Summary
- allow fetching a household by id
- expose household retrieval through API route
- cover household retrieval with tests

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b650945c8326bd028078d5f11c6c