### PR TITLE
feat: list supported currencies with caching

### DIFF
--- a/Backend/src/application/use-cases/get-supported-currencies.usecase.ts
+++ b/Backend/src/application/use-cases/get-supported-currencies.usecase.ts
@@ -1,0 +1,9 @@
+import { ExchangeRateProvider } from '../../infrastructure/currency/exchange-rate.provider';
+
+export class GetSupportedCurrenciesUseCase {
+  constructor(private provider: ExchangeRateProvider) {}
+
+  async execute(baseCurrency: string): Promise<string[]> {
+    return this.provider.fetchSupportedCurrencies(baseCurrency);
+  }
+}

--- a/Backend/src/config/env.ts
+++ b/Backend/src/config/env.ts
@@ -17,6 +17,6 @@ export const config = {
     process.env.FRONTEND_REDIRECT_URI ??
     'http://localhost:4200/auth/google/callback',
   exchangeRateApiBase:
-    process.env.EXCHANGE_RATE_API_BASE ?? 'https://api.exchangerate.host',
-  exchangeRateTtlMinutes: Number(process.env.EXCHANGE_RATE_TTL_MINUTES ?? 60),
+    process.env.EXCHANGE_RATE_API_BASE ?? 'https://open.er-api.com/v6/latest',
+  exchangeRateTtlMinutes: Number(process.env.EXCHANGE_RATE_TTL_MINUTES ?? 1440),
 };

--- a/Backend/src/infrastructure/currency/exchange-rate.provider.ts
+++ b/Backend/src/infrastructure/currency/exchange-rate.provider.ts
@@ -6,25 +6,56 @@ interface FetchRateResult {
   source: string;
 }
 
+interface CachedRates {
+  rates: Record<string, number>;
+  expiresAt: number;
+}
+
 export class ExchangeRateProvider {
+  private cache: Record<string, CachedRates> = {};
+
   constructor(private apiBase = config.exchangeRateApiBase) {}
+
+  private ttlMs = config.exchangeRateTtlMinutes * 60 * 1000;
+
+  private async getRates(
+    baseCurrency: string,
+  ): Promise<Record<string, number>> {
+    const base = baseCurrency.toUpperCase();
+    const cached = this.cache[base];
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.rates;
+    }
+    const url = `${this.apiBase}/${base}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new ExternalServiceError('Failed to fetch exchange rates');
+    }
+    const data = (await response.json()) as { rates?: Record<string, number> };
+    if (!data.rates) {
+      throw new ExternalServiceError('Invalid exchange rate data');
+    }
+    this.cache[base] = {
+      rates: data.rates,
+      expiresAt: Date.now() + this.ttlMs,
+    };
+    return data.rates;
+  }
 
   async fetchRate(
     baseCurrency: string,
     targetCurrency: string,
   ): Promise<FetchRateResult> {
-    const url = `${this.apiBase}/latest?base=${baseCurrency}&symbols=${targetCurrency}`;
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new ExternalServiceError('Failed to fetch exchange rate');
-    }
-    const data = (await response.json()) as {
-      rates?: Record<string, number>;
-    };
-    const rate = data.rates?.[targetCurrency];
+    const rates = await this.getRates(baseCurrency);
+    const rate = rates[targetCurrency.toUpperCase()];
     if (typeof rate !== 'number') {
       throw new ExternalServiceError('Invalid exchange rate data');
     }
     return { rate, source: this.apiBase };
+  }
+
+  async fetchSupportedCurrencies(baseCurrency: string): Promise<string[]> {
+    const rates = await this.getRates(baseCurrency);
+    return Object.keys(rates);
   }
 }

--- a/Backend/src/infrastructure/location/geo-ip.service.ts
+++ b/Backend/src/infrastructure/location/geo-ip.service.ts
@@ -1,4 +1,8 @@
+import { ExchangeRateProvider } from '../currency/exchange-rate.provider';
+
 export class GeoIpService {
+  private readonly exchange = new ExchangeRateProvider();
+
   async getCurrency(ip?: string): Promise<string | null> {
     try {
       const url = ip
@@ -9,7 +13,12 @@ export class GeoIpService {
         return null;
       }
       const data = (await res.json()) as { currency?: string };
-      return data.currency ?? null;
+      const currency = data.currency;
+      if (!currency) {
+        return null;
+      }
+      const supported = await this.exchange.fetchSupportedCurrencies('USD');
+      return supported.includes(currency) ? currency : null;
     } catch {
       return null;
     }

--- a/Backend/src/interfaces/http/controllers/currency.controller.ts
+++ b/Backend/src/interfaces/http/controllers/currency.controller.ts
@@ -3,10 +3,17 @@ import {
   ConvertCurrencyUseCase,
   ConvertCurrencyPayload,
 } from '../../../application/use-cases/convert-currency.usecase';
-import { ConvertCurrencyRequestDto } from '../dto/currency.dto';
+import { GetSupportedCurrenciesUseCase } from '../../../application/use-cases/get-supported-currencies.usecase';
+import {
+  ConvertCurrencyRequestDto,
+  SupportedCurrenciesRequestDto,
+} from '../dto/currency.dto';
 
 export class CurrencyController {
-  constructor(private convertCurrency: ConvertCurrencyUseCase) {}
+  constructor(
+    private convertCurrency: ConvertCurrencyUseCase,
+    private getSupportedCurrencies: GetSupportedCurrenciesUseCase,
+  ) {}
 
   convert = async (req: Request, res: Response) => {
     const { from, to, amount } =
@@ -18,5 +25,13 @@ export class CurrencyController {
     };
     const conversion = await this.convertCurrency.execute(payload);
     res.json({ conversion });
+  };
+
+  supported = async (req: Request, res: Response) => {
+    const { base } = req.query as unknown as SupportedCurrenciesRequestDto;
+    const currencies = await this.getSupportedCurrencies.execute(
+      (base ?? 'USD').toUpperCase(),
+    );
+    res.json({ currencies });
   };
 }

--- a/Backend/src/interfaces/http/dto/currency.dto.ts
+++ b/Backend/src/interfaces/http/dto/currency.dto.ts
@@ -7,3 +7,11 @@ export const convertCurrencySchema = z.object({
 });
 
 export type ConvertCurrencyRequestDto = z.infer<typeof convertCurrencySchema>;
+
+export const supportedCurrenciesSchema = z.object({
+  base: z.string().length(3).optional(),
+});
+
+export type SupportedCurrenciesRequestDto = z.infer<
+  typeof supportedCurrenciesSchema
+>;

--- a/Backend/src/interfaces/http/routes/currency.routes.ts
+++ b/Backend/src/interfaces/http/routes/currency.routes.ts
@@ -4,19 +4,30 @@ import { ExchangeRateRepository } from '../../../infrastructure/persistence/repo
 import { ExchangeRateProvider } from '../../../infrastructure/currency/exchange-rate.provider';
 import { ConvertCurrencyUseCase } from '../../../application/use-cases/convert-currency.usecase';
 import { validate } from '../../middleware/validation.middleware';
-import { convertCurrencySchema } from '../dto/currency.dto';
+import {
+  convertCurrencySchema,
+  supportedCurrenciesSchema,
+} from '../dto/currency.dto';
+import { GetSupportedCurrenciesUseCase } from '../../../application/use-cases/get-supported-currencies.usecase';
 
 const router = Router();
 
 const repo = new ExchangeRateRepository();
 const provider = new ExchangeRateProvider();
-const useCase = new ConvertCurrencyUseCase(repo, provider);
-const controller = new CurrencyController(useCase);
+const convertUseCase = new ConvertCurrencyUseCase(repo, provider);
+const supportedUseCase = new GetSupportedCurrenciesUseCase(provider);
+const controller = new CurrencyController(convertUseCase, supportedUseCase);
 
 router.get(
   '/convert',
   validate({ query: convertCurrencySchema }),
   controller.convert,
+);
+
+router.get(
+  '/supported',
+  validate({ query: supportedCurrenciesSchema }),
+  controller.supported,
 );
 
 export default router;

--- a/Frontend/src/app/core/currency/currency.service.ts
+++ b/Frontend/src/app/core/currency/currency.service.ts
@@ -1,0 +1,15 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, Observable, shareReplay } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class CurrencyService {
+  private readonly http = inject(HttpClient);
+  private readonly supported$ = this.http
+    .get<{ currencies: string[] }>('/currency/supported')
+    .pipe(map((res) => res.currencies), shareReplay(1));
+
+  getSupported(): Observable<string[]> {
+    return this.supported$;
+  }
+}

--- a/Frontend/src/app/core/geo/geo.service.ts
+++ b/Frontend/src/app/core/geo/geo.service.ts
@@ -1,7 +1,12 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+
+import { CurrencyService } from '../currency/currency.service';
 
 @Injectable({ providedIn: 'root' })
 export class GeoService {
+  private readonly currencyService = inject(CurrencyService);
+
   async getCurrency(): Promise<string | null> {
     try {
       const res = await fetch('https://ipapi.co/json/');
@@ -9,9 +14,15 @@ export class GeoService {
         return null;
       }
       const data = (await res.json()) as { currency?: string };
-      return data.currency ?? null;
+      const currency = data.currency;
+      if (!currency) {
+        return null;
+      }
+      const supported = await firstValueFrom(this.currencyService.getSupported());
+      return supported.includes(currency) ? currency : null;
     } catch {
       return null;
     }
   }
 }
+

--- a/Frontend/src/app/features/dashboard/preferences/preferences.component.html
+++ b/Frontend/src/app/features/dashboard/preferences/preferences.component.html
@@ -12,7 +12,7 @@
             <label class="field">
                 <span class="label">Moneda preferida</span>
                 <select class="input" [(ngModel)]="selectedCurrency">
-                    <option *ngFor="let c of currencies" [value]="c">{{ c }}</option>
+                    <option *ngFor="let c of currencies$ | async" [value]="c">{{ c }}</option>
                 </select>
             </label>
             <label class="field">

--- a/Frontend/src/app/features/dashboard/preferences/preferences.component.ts
+++ b/Frontend/src/app/features/dashboard/preferences/preferences.component.ts
@@ -5,6 +5,7 @@ import { FormsModule } from "@angular/forms";
 import { AuthService } from "../../../core/auth/auth.service";
 import { GoogleAuthService } from "../../../core/auth/google-auth.service";
 import { GeoService } from "../../../core/geo/geo.service";
+import { CurrencyService } from "../../../core/currency/currency.service";
 import { take } from "rxjs";
 
 @Component({
@@ -19,9 +20,10 @@ export class PreferencesComponent {
   private readonly authService = inject(AuthService);
   private readonly googleAuth = inject(GoogleAuthService);
   private readonly geo = inject(GeoService);
+  private readonly currencyService = inject(CurrencyService);
 
-  currencies = ["USD", "EUR", "ARS", "MXN"];
-  selectedCurrency = this.currencies[0];
+  readonly currencies$ = this.currencyService.getSupported();
+  selectedCurrency = "USD";
 
   constructor() {
     this.authService.user$.pipe(take(1)).subscribe((user) => {
@@ -49,3 +51,4 @@ export class PreferencesComponent {
       .subscribe();
   }
 }
+

--- a/Frontend/src/app/features/onboarding/onboarding.component.html
+++ b/Frontend/src/app/features/onboarding/onboarding.component.html
@@ -22,10 +22,9 @@
                 <label>
                     Moneda base
                     <select formControlName="baseCurrency">
-                        <option value="USD">USD</option>
-                        <option value="EUR">EUR</option>
-                        <option value="ARS">ARS</option>
-                        <option value="MXN">MXN</option>
+                        <option *ngFor="let c of currencies$ | async" [value]="c">
+                            {{ c }}
+                        </option>
                     </select>
                 </label>
                 <label>

--- a/Frontend/src/app/features/onboarding/onboarding.component.ts
+++ b/Frontend/src/app/features/onboarding/onboarding.component.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule, FormBuilder, Validators } from "@angular/forms";
 import { Router, ActivatedRoute } from "@angular/router";
 
 import { HouseholdService } from "../../core/household/household.service";
+import { CurrencyService } from "../../core/currency/currency.service";
 
 @Component({
   selector: "app-onboarding",
@@ -16,6 +17,7 @@ import { HouseholdService } from "../../core/household/household.service";
 export class OnboardingComponent {
   private readonly fb = inject(FormBuilder);
   private readonly householdService = inject(HouseholdService);
+  private readonly currencyService = inject(CurrencyService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
 
@@ -29,6 +31,8 @@ export class OnboardingComponent {
   readonly inviteForm = this.fb.nonNullable.group({
     token: ["", [Validators.required]],
   });
+
+  readonly currencies$ = this.currencyService.getSupported();
 
   constructor() {
     const token = this.route.snapshot.queryParamMap.get("token");


### PR DESCRIPTION
## Summary
- fetch exchange rates from open ExchangeRate-API and cache results
- expose `/currency/supported` endpoint and use it in onboarding & preferences
- show dynamic currency options on onboarding and preferences using cached backend data
- align IP-based currency detection with supported currencies list

## Testing
- `npm run build` (backend)
- `npm run lint` (backend)
- `npm test` (backend)
- `npm run build` (frontend)
- `npm run lint` (frontend) *(fails: Missing script "lint")*
- `npm test` (frontend) *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6898d19275448326bbdd48aa0f73371d