### PR TITLE
feat: add item and category management

### DIFF
--- a/Frontend/src/app/app.routes.ts
+++ b/Frontend/src/app/app.routes.ts
@@ -54,6 +54,13 @@ export const routes: Routes = [
           ),
       },
       {
+        path: "categorias",
+        loadComponent: () =>
+          import("./features/dashboard/categories/categories.component").then(
+            (m) => m.CategoriesComponent
+          ),
+      },
+      {
         path: "presupuesto",
         loadComponent: () =>
           import("./features/dashboard/budget/budget.component").then(

--- a/Frontend/src/app/core/categories/category.service.ts
+++ b/Frontend/src/app/core/categories/category.service.ts
@@ -1,0 +1,43 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
+import { HouseholdService } from '../household/household.service';
+import { Category } from '../../shared/models/category.model';
+
+export type CreateCategoryPayload = Partial<
+  Pick<Category, 'name' | 'description'>
+>;
+export type UpdateCategoryPayload = CreateCategoryPayload;
+
+@Injectable({ providedIn: 'root' })
+export class CategoryService {
+  private readonly http = inject(HttpClient);
+  private readonly household = inject(HouseholdService);
+
+  list(): Observable<Category[]> {
+    const householdId = this.household.getHouseholdId();
+    return this.http
+      .get<{ categories: Category[] }>(`/households/${householdId}/categories`)
+      .pipe(map(({ categories }) => categories));
+  }
+
+  create(payload: CreateCategoryPayload): Observable<Category> {
+    const householdId = this.household.getHouseholdId();
+    return this.http
+      .post<{ category: Category }>(
+        `/households/${householdId}/categories`,
+        payload,
+      )
+      .pipe(map(({ category }) => category));
+  }
+
+  update(categoryId: string, payload: UpdateCategoryPayload): Observable<Category> {
+    const householdId = this.household.getHouseholdId();
+    return this.http
+      .put<{ category: Category }>(
+        `/households/${householdId}/categories/${categoryId}`,
+        payload,
+      )
+      .pipe(map(({ category }) => category));
+  }
+}

--- a/Frontend/src/app/core/items/items.service.ts
+++ b/Frontend/src/app/core/items/items.service.ts
@@ -1,0 +1,53 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, Observable } from 'rxjs';
+import { HouseholdService } from '../household/household.service';
+import { Item } from '../../shared/models/item.model';
+
+export type CreateItemPayload = Partial<
+  Pick<
+    Item,
+    | 'name'
+    | 'description'
+    | 'categoryId'
+    | 'type'
+    | 'price'
+    | 'currency'
+    | 'priority'
+    | 'status'
+    | 'purchaseLink'
+    | 'paymentSplit'
+  >
+>;
+
+export type UpdateItemPayload = CreateItemPayload;
+
+@Injectable({ providedIn: 'root' })
+export class ItemsService {
+  private readonly http = inject(HttpClient);
+  private readonly household = inject(HouseholdService);
+
+  list(): Observable<Item[]> {
+    const householdId = this.household.getHouseholdId();
+    return this.http
+      .get<{ items: Item[] }>(`/households/${householdId}/items`)
+      .pipe(map(({ items }) => items));
+  }
+
+  create(payload: CreateItemPayload): Observable<Item> {
+    const householdId = this.household.getHouseholdId();
+    return this.http
+      .post<{ item: Item }>(`/households/${householdId}/items`, payload)
+      .pipe(map(({ item }) => item));
+  }
+
+  update(itemId: string, payload: UpdateItemPayload): Observable<Item> {
+    const householdId = this.household.getHouseholdId();
+    return this.http
+      .put<{ item: Item }>(
+        `/households/${householdId}/items/${itemId}`,
+        payload,
+      )
+      .pipe(map(({ item }) => item));
+  }
+}

--- a/Frontend/src/app/features/dashboard/categories/categories.component.html
+++ b/Frontend/src/app/features/dashboard/categories/categories.component.html
@@ -1,0 +1,20 @@
+<div class="subheader">
+  <h2>Categorías</h2>
+</div>
+
+<section class="categories">
+  <ul class="list">
+    <li class="item" *ngFor="let cat of categories()">
+      <div class="item__title">{{ cat.name }}</div>
+      <button class="btn" (click)="edit(cat)">Editar</button>
+    </li>
+  </ul>
+
+  <form class="form-grid" [formGroup]="categoryForm" (ngSubmit)="save()">
+    <label>Nombre<input type="text" formControlName="name" /></label>
+    <label>Descripción<input type="text" formControlName="description" /></label>
+    <button class="btn primary" type="submit">
+      {{ editingId() ? 'Actualizar' : 'Crear' }}
+    </button>
+  </form>
+</section>

--- a/Frontend/src/app/features/dashboard/categories/categories.component.scss
+++ b/Frontend/src/app/features/dashboard/categories/categories.component.scss
@@ -1,0 +1,26 @@
+.subheader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-3);
+}
+
+.list {
+  display: grid;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3);
+  background: var(--base-100);
+  border-radius: var(--radius-2);
+}
+
+.form-grid {
+  display: grid;
+  gap: var(--space-3);
+}

--- a/Frontend/src/app/features/dashboard/categories/categories.component.ts
+++ b/Frontend/src/app/features/dashboard/categories/categories.component.ts
@@ -1,0 +1,65 @@
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { CategoryService } from '../../../core/categories/category.service';
+import { Category } from '../../../shared/models/category.model';
+
+@Component({
+  selector: 'app-categories',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './categories.component.html',
+  styleUrl: './categories.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CategoriesComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly categoryService = inject(CategoryService);
+
+  readonly categories = signal<Category[]>([]);
+
+  readonly categoryForm = this.fb.nonNullable.group({
+    name: ['', Validators.required],
+    description: [''],
+  });
+
+  readonly editingId = signal<string | null>(null);
+
+  constructor() {
+    this.load();
+  }
+
+  load(): void {
+    this.categoryService.list().subscribe((cats) => this.categories.set(cats));
+  }
+
+  edit(cat: Category): void {
+    this.editingId.set(cat.id);
+    this.categoryForm.patchValue({
+      name: cat.name,
+      description: cat.description ?? '',
+    });
+  }
+
+  save(): void {
+    if (this.categoryForm.invalid) {
+      return;
+    }
+    const data = this.categoryForm.getRawValue();
+    const id = this.editingId();
+    if (id) {
+      this.categoryService.update(id, data).subscribe((updated) => {
+        this.categories.update((list) =>
+          list.map((c) => (c.id === updated.id ? updated : c)),
+        );
+        this.categoryForm.reset();
+        this.editingId.set(null);
+      });
+    } else {
+      this.categoryService.create(data).subscribe((created) => {
+        this.categories.update((list) => [...list, created]);
+        this.categoryForm.reset();
+      });
+    }
+  }
+}

--- a/Frontend/src/app/features/dashboard/items/items.component.html
+++ b/Frontend/src/app/features/dashboard/items/items.component.html
@@ -1,9 +1,9 @@
 <div class="subheader">
     <h2>Ítems</h2>
     <div class="actions desktop-only">
-        <button class="btn primary" (click)="showNewItemModal.set(true)">Nuevo ítem</button>
+        <button class="btn primary" (click)="openNew()">Nuevo ítem</button>
     </div>
-    <button class="fab mobile-only" aria-label="Nuevo ítem" (click)="showNewItemModal.set(true)">＋</button>
+    <button class="fab mobile-only" aria-label="Nuevo ítem" (click)="openNew()">＋</button>
     <div class="sr-only">Botón de acción flotante para crear un nuevo ítem</div>
 </div>
 
@@ -22,69 +22,54 @@
     </div>
 
     <div class="list grid">
-        <div class="item card">
+        <div class="item card" *ngFor="let item of items()">
             <div class="item__head">
                 <div>
-                    <div class="item__title">Ejemplo de ítem</div>
-                    <div class="item__meta">Muebles • Por cotizar</div>
+                    <div class="item__title">{{ item.name }}</div>
+                    <div class="item__meta">{{ getCategoryName(item.categoryId) }} • {{ item.status }}</div>
                 </div>
-                <div class="item__price">$ 0</div>
+                <div class="item__price">{{ item.price | currency:item.currency }}</div>
             </div>
             <div class="item__footer">
                 <div class="split">50% tú • 50% pareja</div>
                 <div class="tags">
-                    <span class="tag">Prioridad: Necesario</span>
-                    <button class="btn" (click)="showSplitModal.set(true)">Dividir pago</button>
+                    <span class="tag">Prioridad: {{ item.priority }}</span>
+                    <button class="btn" (click)="edit(item)">Editar</button>
                 </div>
             </div>
         </div>
     </div>
 </section>
 
-<!-- Modal: Nuevo ítem (solo UI) -->
 <div class="modal" [class.open]="showNewItemModal()">
     <div class="backdrop" (click)="showNewItemModal.set(false)"></div>
     <div class="dialog card">
         <div class="dialog__header">
-            <h3>Nuevo ítem</h3>
+            <h3>{{ editingId() ? 'Editar ítem' : 'Nuevo ítem' }}</h3>
             <button class="icon" (click)="showNewItemModal.set(false)">✕</button>
         </div>
-        <div class="dialog__body">
-            <div class="form-grid">
-                <label>Nombre<input type="text" placeholder="Sillón" /></label>
-                <label>Categoría<select>
-                        <option>Muebles</option>
-                        <option>Electro</option>
-                        <option>Servicios</option>
+        <form class="dialog__body form-grid" [formGroup]="itemForm">
+            <label>Nombre<input type="text" placeholder="Sillón" formControlName="name" /></label>
+            <label>Categoría<select formControlName="categoryId">
+                        <option value="">Sin categoría</option>
+                        <option *ngFor="let cat of categories()" [value]="cat.id">{{ cat.name }}</option>
                     </select></label>
-                <label>Tipo<select>
-                        <option>Único</option>
-                        <option>Recurrente</option>
+            <label>Tipo<select formControlName="type">
+                        <option *ngFor="let t of itemTypes" [value]="t">{{ t }}</option>
                     </select></label>
-                <label>Precio<input type="number" placeholder="0" /></label>
-                <label>Moneda<select>
-                        <option>USD</option>
-                        <option>EUR</option>
-                        <option>ARS</option>
-                        <option>MXN</option>
+            <label>Precio<input type="number" placeholder="0" formControlName="price" /></label>
+            <label>Moneda<input type="text" formControlName="currency" /></label>
+            <label>Prioridad<select formControlName="priority">
+                        <option *ngFor="let p of itemPriorities" [value]="p">{{ p }}</option>
                     </select></label>
-                <label>Prioridad<select>
-                        <option>Necesario</option>
-                        <option>Opcional</option>
-                        <option>Capricho</option>
+            <label>Estado<select formControlName="status">
+                        <option *ngFor="let s of itemStatuses" [value]="s">{{ s }}</option>
                     </select></label>
-                <label>Estado<select>
-                        <option>Por cotizar</option>
-                        <option>Cotizado</option>
-                        <option>Comprado</option>
-                        <option>Descartado</option>
-                    </select></label>
-                <label>Link de compra<input type="text" placeholder="https://..." /></label>
-            </div>
-        </div>
+            <label>Link de compra<input type="text" placeholder="https://..." formControlName="purchaseLink" /></label>
+        </form>
         <div class="dialog__actions">
             <button class="btn" (click)="showNewItemModal.set(false)">Cancelar</button>
-            <button class="btn primary">Guardar</button>
+            <button class="btn primary" (click)="save()">Guardar</button>
         </div>
     </div>
 </div>

--- a/Frontend/src/app/features/dashboard/items/items.component.ts
+++ b/Frontend/src/app/features/dashboard/items/items.component.ts
@@ -1,16 +1,111 @@
-import { ChangeDetectionStrategy, Component, signal } from "@angular/core";
-import { CommonModule } from "@angular/common";
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { ItemsService } from '../../../core/items/items.service';
+import { CategoryService } from '../../../core/categories/category.service';
+import { Item } from '../../../shared/models/item.model';
+import { Category } from '../../../shared/models/category.model';
+import { ItemType } from '../../../shared/models/item-type.enum';
+import { ItemPriority } from '../../../shared/models/item-priority.enum';
+import { ItemStatus } from '../../../shared/models/item-status.enum';
 
 @Component({
-  selector: "app-items",
+  selector: 'app-items',
   standalone: true,
-  imports: [CommonModule],
-  templateUrl: "./items.component.html",
-  styleUrl: "./items.component.scss",
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './items.component.html',
+  styleUrl: './items.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ItemsComponent {
-  // Solo UI: toggles locales para modales
+  private readonly fb = inject(FormBuilder);
+  private readonly itemsService = inject(ItemsService);
+  private readonly categoryService = inject(CategoryService);
+
+  readonly items = signal<Item[]>([]);
+  readonly categories = signal<Category[]>([]);
+
+  readonly itemTypes = Object.values(ItemType);
+  readonly itemPriorities = Object.values(ItemPriority);
+  readonly itemStatuses = Object.values(ItemStatus);
+
+  readonly itemForm = this.fb.nonNullable.group({
+    name: ['', Validators.required],
+    categoryId: [''],
+    type: [ItemType.ONE_TIME, Validators.required],
+    price: [0, Validators.required],
+    currency: ['USD', Validators.required],
+    priority: [ItemPriority.NECESSARY, Validators.required],
+    status: [ItemStatus.TO_QUOTE, Validators.required],
+    purchaseLink: [''],
+  });
+
   showNewItemModal = signal(false);
   showSplitModal = signal(false);
+  readonly editingId = signal<string | null>(null);
+
+  constructor() {
+    this.load();
+  }
+
+  load(): void {
+    this.itemsService.list().subscribe((items) => this.items.set(items));
+    this.categoryService.list().subscribe((cats) => this.categories.set(cats));
+  }
+
+  openNew(): void {
+    this.editingId.set(null);
+    this.itemForm.reset({
+      name: '',
+      categoryId: '',
+      type: ItemType.ONE_TIME,
+      price: 0,
+      currency: 'USD',
+      priority: ItemPriority.NECESSARY,
+      status: ItemStatus.TO_QUOTE,
+      purchaseLink: '',
+    });
+    this.showNewItemModal.set(true);
+  }
+
+  edit(item: Item): void {
+    this.editingId.set(item.id);
+    this.itemForm.patchValue({
+      name: item.name,
+      categoryId: item.categoryId ?? '',
+      type: item.type,
+      price: item.price,
+      currency: item.currency,
+      priority: item.priority,
+      status: item.status,
+      purchaseLink: item.purchaseLink ?? '',
+    });
+    this.showNewItemModal.set(true);
+  }
+
+  getCategoryName(id?: string): string {
+    const cat = this.categories().find((c) => c.id === id);
+    return cat ? cat.name : '';
+  }
+
+  save(): void {
+    if (this.itemForm.invalid) {
+      return;
+    }
+    const data = this.itemForm.getRawValue();
+    const id = this.editingId();
+    if (id) {
+      this.itemsService.update(id, data).subscribe((updated) => {
+        this.items.update((list) =>
+          list.map((i) => (i.id === updated.id ? updated : i)),
+        );
+        this.showNewItemModal.set(false);
+      });
+    } else {
+      this.itemsService.create(data).subscribe((created) => {
+        this.items.update((list) => [...list, created]);
+        this.showNewItemModal.set(false);
+      });
+    }
+  }
 }

--- a/Frontend/src/app/features/home/home.component.html
+++ b/Frontend/src/app/features/home/home.component.html
@@ -22,6 +22,10 @@
             <span class="icon">🧺</span>
             <span class="label">Ítems</span>
         </a>
+        <a routerLink="/home/categorias" routerLinkActive="active" aria-label="Categorías">
+            <span class="icon">🏷️</span>
+            <span class="label">Categorías</span>
+        </a>
         <a routerLink="/home/presupuesto" routerLinkActive="active" aria-label="Presupuesto">
             <span class="icon">💰</span>
             <span class="label">Presupuesto</span>

--- a/Frontend/src/app/shared/models/category.model.ts
+++ b/Frontend/src/app/shared/models/category.model.ts
@@ -1,0 +1,10 @@
+export interface Category {
+  id: string;
+  householdId: string;
+  name: string;
+  description?: string;
+  order?: number;
+  isBase?: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/Frontend/src/app/shared/models/item-priority.enum.ts
+++ b/Frontend/src/app/shared/models/item-priority.enum.ts
@@ -1,0 +1,5 @@
+export enum ItemPriority {
+  NECESSARY = 'necessary',
+  OPTIONAL = 'optional',
+  WHIM = 'whim',
+}

--- a/Frontend/src/app/shared/models/item-status.enum.ts
+++ b/Frontend/src/app/shared/models/item-status.enum.ts
@@ -1,0 +1,6 @@
+export enum ItemStatus {
+  TO_QUOTE = 'to_quote',
+  QUOTED = 'quoted',
+  PURCHASED = 'purchased',
+  DISCARDED = 'discarded',
+}

--- a/Frontend/src/app/shared/models/item-type.enum.ts
+++ b/Frontend/src/app/shared/models/item-type.enum.ts
@@ -1,0 +1,4 @@
+export enum ItemType {
+  ONE_TIME = 'one_time',
+  RECURRING = 'recurring',
+}

--- a/Frontend/src/app/shared/models/item.model.ts
+++ b/Frontend/src/app/shared/models/item.model.ts
@@ -1,0 +1,28 @@
+import { ItemPriority } from './item-priority.enum';
+import { ItemStatus } from './item-status.enum';
+import { ItemType } from './item-type.enum';
+import { PaymentSplit } from './payment-split.model';
+
+export interface Item {
+  id: string;
+  householdId: string;
+  name: string;
+  description?: string;
+  categoryId?: string;
+  type: ItemType;
+  price: number;
+  currency: string;
+  purchaseLink?: string;
+  imageUrls?: string[];
+  status: ItemStatus;
+  priority: ItemPriority;
+  paymentSplit?: PaymentSplit;
+  estimatedPurchaseDate?: string;
+  purchasedAt?: string;
+  tags?: string[];
+  createdAt: string;
+  updatedAt: string;
+  lastModifiedBy: string;
+  lastModifiedByName?: string;
+  metadata?: Record<string, unknown>;
+}

--- a/Frontend/src/app/shared/models/payment-split.model.ts
+++ b/Frontend/src/app/shared/models/payment-split.model.ts
@@ -1,0 +1,11 @@
+export interface PaymentAssignment {
+  userId: string;
+  percentage?: number;
+  amount?: number;
+  calculatedAmount?: number;
+  label?: string;
+}
+
+export interface PaymentSplit {
+  assignments: PaymentAssignment[];
+}


### PR DESCRIPTION
## Summary
- support listing, creating and updating items through new ItemsService and UI
- add category model, service and management component with routing
- expose item and category enums for frontend use

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build`
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68996bacd5948326b6fe88eab901f186