### PR TITLE
Muestra etiquetas en español para ítems

### DIFF
--- a/Frontend/src/app/features/dashboard/items/items.component.html
+++ b/Frontend/src/app/features/dashboard/items/items.component.html
@@ -26,14 +26,14 @@
             <div class="item__head">
                 <div>
                     <div class="item__title">{{ item.name }}</div>
-                    <div class="item__meta">{{ getCategoryName(item.categoryId) }} • {{ item.status }}</div>
+                    <div class="item__meta">{{ getCategoryName(item.categoryId) }} • {{ getStatusLabel(item.status) }}</div>
                 </div>
                 <div class="item__price">{{ item.price | currency:item.currency }}</div>
             </div>
             <div class="item__footer">
                 <div class="split">50% tú • 50% pareja</div>
                 <div class="tags">
-                    <span class="tag">Prioridad: {{ item.priority }}</span>
+                    <span class="tag">Prioridad: {{ getPriorityLabel(item.priority) }}</span>
                     <button class="btn" (click)="edit(item)">Editar</button>
                 </div>
             </div>
@@ -55,15 +55,15 @@
                         <option *ngFor="let cat of categories()" [value]="cat.id">{{ cat.name }}</option>
                     </select></label>
             <label>Tipo<select formControlName="type">
-                        <option *ngFor="let t of itemTypes" [value]="t">{{ t }}</option>
+                        <option *ngFor="let t of itemTypeOptions" [value]="t.value">{{ t.label }}</option>
                     </select></label>
             <label>Precio<input type="number" placeholder="0" formControlName="price" /></label>
             <label>Moneda<input type="text" formControlName="currency" /></label>
             <label>Prioridad<select formControlName="priority">
-                        <option *ngFor="let p of itemPriorities" [value]="p">{{ p }}</option>
+                        <option *ngFor="let p of itemPriorityOptions" [value]="p.value">{{ p.label }}</option>
                     </select></label>
             <label>Estado<select formControlName="status">
-                        <option *ngFor="let s of itemStatuses" [value]="s">{{ s }}</option>
+                        <option *ngFor="let s of itemStatusOptions" [value]="s.value">{{ s.label }}</option>
                     </select></label>
             <label>Link de compra<input type="text" placeholder="https://..." formControlName="purchaseLink" /></label>
         </form>

--- a/Frontend/src/app/features/dashboard/items/items.component.ts
+++ b/Frontend/src/app/features/dashboard/items/items.component.ts
@@ -8,6 +8,11 @@ import { Category } from '../../../shared/models/category.model';
 import { ItemType } from '../../../shared/models/item-type.enum';
 import { ItemPriority } from '../../../shared/models/item-priority.enum';
 import { ItemStatus } from '../../../shared/models/item-status.enum';
+import {
+  ITEM_TYPE_LABELS,
+  ITEM_PRIORITY_LABELS,
+  ITEM_STATUS_LABELS,
+} from '../../../shared/models/item-labels';
 
 @Component({
   selector: 'app-items',
@@ -25,9 +30,22 @@ export class ItemsComponent {
   readonly items = signal<Item[]>([]);
   readonly categories = signal<Category[]>([]);
 
-  readonly itemTypes = Object.values(ItemType);
-  readonly itemPriorities = Object.values(ItemPriority);
-  readonly itemStatuses = Object.values(ItemStatus);
+  readonly itemTypeOptions = Object.values(ItemType).map((value) => ({
+    value,
+    label: ITEM_TYPE_LABELS[value],
+  }));
+
+  readonly itemPriorityOptions = Object.values(ItemPriority).map(
+    (value) => ({
+      value,
+      label: ITEM_PRIORITY_LABELS[value],
+    }),
+  );
+
+  readonly itemStatusOptions = Object.values(ItemStatus).map((value) => ({
+    value,
+    label: ITEM_STATUS_LABELS[value],
+  }));
 
   readonly itemForm = this.fb.nonNullable.group({
     name: ['', Validators.required],
@@ -86,6 +104,14 @@ export class ItemsComponent {
   getCategoryName(id?: string): string {
     const cat = this.categories().find((c) => c.id === id);
     return cat ? cat.name : '';
+  }
+
+  getStatusLabel(status: ItemStatus): string {
+    return ITEM_STATUS_LABELS[status];
+  }
+
+  getPriorityLabel(priority: ItemPriority): string {
+    return ITEM_PRIORITY_LABELS[priority];
   }
 
   save(): void {

--- a/Frontend/src/app/shared/models/item-labels.ts
+++ b/Frontend/src/app/shared/models/item-labels.ts
@@ -1,0 +1,22 @@
+import { ItemType } from './item-type.enum';
+import { ItemPriority } from './item-priority.enum';
+import { ItemStatus } from './item-status.enum';
+
+export const ITEM_TYPE_LABELS: Record<ItemType, string> = {
+  [ItemType.ONE_TIME]: 'Único',
+  [ItemType.RECURRING]: 'Recurrente',
+};
+
+export const ITEM_PRIORITY_LABELS: Record<ItemPriority, string> = {
+  [ItemPriority.NECESSARY]: 'Necesario',
+  [ItemPriority.OPTIONAL]: 'Opcional',
+  [ItemPriority.WHIM]: 'Capricho',
+};
+
+export const ITEM_STATUS_LABELS: Record<ItemStatus, string> = {
+  [ItemStatus.TO_QUOTE]: 'A cotizar',
+  [ItemStatus.QUOTED]: 'Cotizado',
+  [ItemStatus.PURCHASED]: 'Comprado',
+  [ItemStatus.DISCARDED]: 'Descartado',
+};
+


### PR DESCRIPTION
## Summary
- Añade diccionarios de etiquetas en español para tipos, prioridades y estados de ítems
- Usa opciones `{ value, label }` en el componente de ítems y helpers para mostrar las etiquetas

## Testing
- `npm run lint` *(falla: Missing script "lint")*
- `npm run test` *(falla: No binary for Chrome browser on your platform)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a3d2012088326adcbc80666ab5db1