### PR TITLE
Configura locale español y servicio de formato de moneda

### DIFF
--- a/Frontend/src/app/shared/services/currency-format.service.ts
+++ b/Frontend/src/app/shared/services/currency-format.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class CurrencyFormatService {
+  private readonly formatter = new Intl.NumberFormat('es-ES', {
+    useGrouping: true,
+  });
+
+  format(value: number): string {
+    return this.formatter.format(value);
+  }
+
+  parse(value: string): number {
+    const groupSymbol = this.formatter
+      .formatToParts(1000)
+      .find((part) => part.type === 'group')?.value ?? '.';
+    const decimalSymbol = this.formatter
+      .formatToParts(1.1)
+      .find((part) => part.type === 'decimal')?.value ?? ',';
+    const normalized = value
+      .replace(new RegExp(`\\${groupSymbol}`, 'g'), '')
+      .replace(decimalSymbol, '.');
+    return Number(normalized);
+  }
+}

--- a/Frontend/src/main.ts
+++ b/Frontend/src/main.ts
@@ -1,6 +1,13 @@
 import { bootstrapApplication } from '@angular/platform-browser';
+import { LOCALE_ID } from '@angular/core';
+import { registerLocaleData } from '@angular/common';
+import localeEs from '@angular/common/locales/es';
+
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
 
-bootstrapApplication(App, appConfig)
-  .catch((err) => console.error(err));
+registerLocaleData(localeEs);
+bootstrapApplication(App, {
+  ...appConfig,
+  providers: [...(appConfig.providers ?? []), { provide: LOCALE_ID, useValue: 'es-ES' }],
+}).catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- Registra datos de localización en español y fija LOCALE_ID en la aplicación
- Añade CurrencyFormatService para formatear y parsear montos en es-ES

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(falla: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed.)*
- `npm run lint` *(falla: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689a4a4e6da88326ac7a8e2cf106fd07