### PR TITLE
feat: agrega directiva currencyInput y aplica en formularios

### DIFF
--- a/Frontend/src/app/features/dashboard/budget/budget.component.html
+++ b/Frontend/src/app/features/dashboard/budget/budget.component.html
@@ -32,8 +32,8 @@
             </div>
             <div class="dialog__body">
                 <div class="form-grid">
-                    <label>Presupuesto inicial<input type="number" placeholder="0" /></label>
-                    <label>Presupuesto mensual<input type="number" placeholder="0" /></label>
+                    <label>Presupuesto inicial<input type="text" placeholder="0" currencyInput /></label>
+                    <label>Presupuesto mensual<input type="text" placeholder="0" currencyInput /></label>
                     <label>Moneda<select>
                             <option>USD</option>
                             <option>EUR</option>

--- a/Frontend/src/app/features/dashboard/budget/budget.component.ts
+++ b/Frontend/src/app/features/dashboard/budget/budget.component.ts
@@ -1,10 +1,11 @@
-import { ChangeDetectionStrategy, Component, signal } from "@angular/core";
-import { CommonModule } from "@angular/common";
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CurrencyInputDirective } from '../../../shared/directives/currency-input.directive';
 
 @Component({
   selector: "app-budget",
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, CurrencyInputDirective],
   templateUrl: "./budget.component.html",
   styleUrl: "./budget.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/Frontend/src/app/features/dashboard/items/items.component.html
+++ b/Frontend/src/app/features/dashboard/items/items.component.html
@@ -57,7 +57,7 @@
             <label>Tipo<select formControlName="type">
                         <option *ngFor="let t of itemTypeOptions" [value]="t.value">{{ t.label }}</option>
                     </select></label>
-            <label>Precio<input type="number" placeholder="0" formControlName="price" /></label>
+            <label>Precio<input type="text" placeholder="0" formControlName="price" currencyInput /></label>
             <label>Moneda<select formControlName="currency">
                         <option *ngFor="let c of currencies$ | async" [value]="c">{{ c }}</option>
                     </select></label>

--- a/Frontend/src/app/features/dashboard/items/items.component.ts
+++ b/Frontend/src/app/features/dashboard/items/items.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { CurrencyInputDirective } from '../../../shared/directives/currency-input.directive';
 import { ItemsService } from '../../../core/items/items.service';
 import { CategoryService } from '../../../core/categories/category.service';
 import { Item } from '../../../shared/models/item.model';
@@ -20,7 +21,7 @@ import { take } from 'rxjs';
 @Component({
   selector: 'app-items',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, CurrencyInputDirective],
   templateUrl: './items.component.html',
   styleUrl: './items.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -133,6 +134,7 @@ export class ItemsComponent {
       return;
     }
     const data = this.itemForm.getRawValue();
+    data.price = Number(data.price);
     const id = this.editingId();
     if (id) {
       this.itemsService.update(id, data).subscribe((updated) => {

--- a/Frontend/src/app/shared/directives/currency-input.directive.ts
+++ b/Frontend/src/app/shared/directives/currency-input.directive.ts
@@ -1,0 +1,56 @@
+import { Directive, ElementRef, HostListener, forwardRef, inject } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { CurrencyFormatService } from '../services/currency-format.service';
+
+@Directive({
+  selector: '[currencyInput]',
+  standalone: true,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => CurrencyInputDirective),
+      multi: true,
+    },
+  ],
+})
+export class CurrencyInputDirective implements ControlValueAccessor {
+  private readonly elementRef = inject(ElementRef<HTMLInputElement>);
+  private readonly currencyFormat = inject(CurrencyFormatService);
+
+  private onChange: (value: number) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  writeValue(value: number | null): void {
+    const formatted =
+      value !== null && value !== undefined
+        ? this.currencyFormat.format(value)
+        : '';
+    this.elementRef.nativeElement.value = formatted;
+  }
+
+  registerOnChange(fn: (value: number) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.elementRef.nativeElement.disabled = isDisabled;
+  }
+
+  @HostListener('input', ['$event'])
+  handleInput(event: Event): void {
+    const value = (event.target as HTMLInputElement | null)?.value ?? '';
+    const numeric = value ? this.currencyFormat.parse(value) : 0;
+    this.onChange(numeric);
+    const formatted = value ? this.currencyFormat.format(numeric) : '';
+    this.elementRef.nativeElement.value = formatted;
+  }
+
+  @HostListener('blur')
+  handleBlur(): void {
+    this.onTouched();
+  }
+}


### PR DESCRIPTION
## Summary
- add CurrencyInputDirective to format and parse values with CurrencyFormatService
- use currencyInput on item and budget price fields
- ensure item price is numeric before saving

## Testing
- `npm run build`
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689a4dbcc43c8326a4d5939071327830