### PR TITLE
feat(frontend): add currencyFormat pipe and replace currency usages

### DIFF
--- a/Frontend/AGENTS.md
+++ b/Frontend/AGENTS.md
@@ -98,6 +98,7 @@ src/
 ## 8. Internacionalización y formato  
 - Soporte para múltiples monedas y formatos numéricos.  
 - Abstraer formateo de moneda/fechas en servicios reutilizables.  
+- Utilizar el pipe `currencyFormat` para mostrar montos con separadores de miles.
 - Evitar hardcodear strings: preparar para i18n si se expande.  
 
 ---

--- a/Frontend/src/app/features/dashboard/budget/budget.component.html
+++ b/Frontend/src/app/features/dashboard/budget/budget.component.html
@@ -12,11 +12,11 @@
         <div class="row">
             <div class="tile">
                 <div class="label">Inicial</div>
-                <div class="value">$ 0</div>
+                <div class="value">{{ 0 | currencyFormat }}</div>
             </div>
             <div class="tile">
                 <div class="label">Mensual</div>
-                <div class="value">$ 0</div>
+                <div class="value">{{ 0 | currencyFormat }}</div>
             </div>
         </div>
         <button class="btn" style="margin-top:10px">Editar</button>
@@ -53,11 +53,11 @@
         <div class="row">
             <div class="tile">
                 <div class="label">Tú</div>
-                <div class="value">$ 0</div>
+                <div class="value">{{ 0 | currencyFormat }}</div>
             </div>
             <div class="tile">
                 <div class="label">Pareja</div>
-                <div class="value">$ 0</div>
+                <div class="value">{{ 0 | currencyFormat }}</div>
             </div>
         </div>
     </div>

--- a/Frontend/src/app/features/dashboard/budget/budget.component.ts
+++ b/Frontend/src/app/features/dashboard/budget/budget.component.ts
@@ -1,11 +1,12 @@
 import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CurrencyInputDirective } from '../../../shared/directives/currency-input.directive';
+import { CurrencyFormatPipe } from '../../../shared/pipes/currency-format.pipe';
 
 @Component({
   selector: "app-budget",
   standalone: true,
-  imports: [CommonModule, CurrencyInputDirective],
+  imports: [CommonModule, CurrencyInputDirective, CurrencyFormatPipe],
   templateUrl: "./budget.component.html",
   styleUrl: "./budget.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/Frontend/src/app/features/dashboard/items/items.component.html
+++ b/Frontend/src/app/features/dashboard/items/items.component.html
@@ -28,7 +28,7 @@
                     <div class="item__title">{{ item.name }}</div>
                     <div class="item__meta">{{ getCategoryName(item.categoryId) }} • {{ getStatusLabel(item.status) }}</div>
                 </div>
-                <div class="item__price">{{ item.price | currency:item.currency }}</div>
+                <div class="item__price">{{ item.price | currencyFormat }} {{ item.currency }}</div>
             </div>
             <div class="item__footer">
                 <div class="split">50% tú • 50% pareja</div>

--- a/Frontend/src/app/features/dashboard/items/items.component.ts
+++ b/Frontend/src/app/features/dashboard/items/items.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/cor
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { CurrencyInputDirective } from '../../../shared/directives/currency-input.directive';
+import { CurrencyFormatPipe } from '../../../shared/pipes/currency-format.pipe';
 import { ItemsService } from '../../../core/items/items.service';
 import { CategoryService } from '../../../core/categories/category.service';
 import { Item } from '../../../shared/models/item.model';
@@ -21,7 +22,7 @@ import { take } from 'rxjs';
 @Component({
   selector: 'app-items',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, CurrencyInputDirective],
+  imports: [CommonModule, ReactiveFormsModule, CurrencyInputDirective, CurrencyFormatPipe],
   templateUrl: './items.component.html',
   styleUrl: './items.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/Frontend/src/app/features/dashboard/summary/summary.component.html
+++ b/Frontend/src/app/features/dashboard/summary/summary.component.html
@@ -9,14 +9,14 @@
     <div class="card" style="display:flex; gap:10px; align-items:center; justify-content:space-between;">
         <div>
             <div style="font-size:12px; color:var(--muted)">Presupuesto inicial</div>
-            <div style="font-size:22px; font-weight:700">$ 0</div>
+            <div style="font-size:22px; font-weight:700">{{ 0 | currencyFormat }}</div>
         </div>
         <div class="badge">0% usado</div>
     </div>
     <div class="card" style="display:flex; gap:10px; align-items:center; justify-content:space-between;">
         <div>
             <div style="font-size:12px; color:var(--muted)">Mensual estimado</div>
-            <div style="font-size:22px; font-weight:700">$ 0 / mes</div>
+            <div style="font-size:22px; font-weight:700">{{ 0 | currencyFormat }} / mes</div>
         </div>
         <div class="badge">0 ítems</div>
     </div>

--- a/Frontend/src/app/features/dashboard/summary/summary.component.ts
+++ b/Frontend/src/app/features/dashboard/summary/summary.component.ts
@@ -1,10 +1,11 @@
 import { ChangeDetectionStrategy, Component } from "@angular/core";
 import { CommonModule } from "@angular/common";
+import { CurrencyFormatPipe } from "../../../shared/pipes/currency-format.pipe";
 
 @Component({
   selector: "app-summary",
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, CurrencyFormatPipe],
   templateUrl: "./summary.component.html",
   styleUrl: "./summary.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/Frontend/src/app/shared/pipes/currency-format.pipe.ts
+++ b/Frontend/src/app/shared/pipes/currency-format.pipe.ts
@@ -1,0 +1,17 @@
+import { Pipe, PipeTransform, inject } from '@angular/core';
+import { CurrencyFormatService } from '../services/currency-format.service';
+
+@Pipe({
+  name: 'currencyFormat',
+  standalone: true,
+})
+export class CurrencyFormatPipe implements PipeTransform {
+  private readonly currencyFormat = inject(CurrencyFormatService);
+
+  transform(value: number | null | undefined): string {
+    if (value == null) {
+      return '';
+    }
+    return this.currencyFormat.format(value);
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone `currencyFormat` pipe delegating to `CurrencyFormatService`
- replace built-in `currency` pipe with `currencyFormat` in dashboard templates
- document using `currencyFormat` pipe for monetary values

## Testing
- `npm ci`
- `npm run build`
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test` *(fails: No binary for Chrome browser on platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a50a018a08326a53f3f67125c6800