### PR TITLE
feat(items): add payment split modal

### DIFF
--- a/Frontend/src/app/features/dashboard/items/items.component.html
+++ b/Frontend/src/app/features/dashboard/items/items.component.html
@@ -68,6 +68,7 @@
                         <option *ngFor="let s of itemStatusOptions" [value]="s.value">{{ s.label }}</option>
                     </select></label>
             <label>Link de compra<input type="text" placeholder="https://..." formControlName="purchaseLink" /></label>
+            <button class="btn" type="button" (click)="openSplit()">Dividir pago</button>
         </form>
         <div class="dialog__actions">
             <button class="btn" (click)="showNewItemModal.set(false)">Cancelar</button>
@@ -75,25 +76,11 @@
         </div>
     </div>
 </div>
-
-<!-- Modal: Dividir pago (solo UI) -->
-<div class="modal" [class.open]="showSplitModal()">
-    <div class="backdrop" (click)="showSplitModal.set(false)"></div>
-    <div class="dialog card">
-        <div class="dialog__header">
-            <h3>Dividir pago</h3>
-            <button class="icon" (click)="showSplitModal.set(false)">✕</button>
-        </div>
-        <div class="dialog__body">
-            <div class="split-grid">
-                <label>Tu aporte (%)<input type="number" value="50" /></label>
-                <label>Pareja (%)<input type="number" value="50" /></label>
-            </div>
-            <p class="text-muted" style="margin-top:8px">Puedes usar porcentajes. En el futuro se soportarán montos.</p>
-        </div>
-        <div class="dialog__actions">
-            <button class="btn" (click)="showSplitModal.set(false)">Cancelar</button>
-            <button class="btn primary">Aplicar</button>
-        </div>
-    </div>
-</div>
+<app-split-modal
+    *ngIf="showSplitModal()"
+    [members]="members"
+    [total]="itemForm.get('price')?.value || 0"
+    [initialSplit]="paymentSplit()"
+    (cancel)="showSplitModal.set(false)"
+    (save)="onSplitSave($event)"
+></app-split-modal>

--- a/Frontend/src/app/features/dashboard/items/split-modal.component.html
+++ b/Frontend/src/app/features/dashboard/items/split-modal.component.html
@@ -1,0 +1,30 @@
+<div class="modal open">
+  <div class="backdrop" (click)="cancel.emit()"></div>
+  <div class="dialog card">
+    <div class="dialog__header">
+      <h3>Dividir pago</h3>
+      <button class="icon" (click)="cancel.emit()">✕</button>
+    </div>
+    <form class="dialog__body" [formGroup]="form">
+      <div class="split-grid" formArrayName="assignments">
+        <div class="assignment" *ngFor="let ctrl of assignments.controls; let i = index" [formGroupName]="i">
+          <label>
+            {{ ctrl.get('label')?.value }} (%)
+            <input type="number" formControlName="percentage" (input)="onChange()" />
+          </label>
+          <label>
+            {{ ctrl.get('label')?.value }} (monto)
+            <input type="number" formControlName="amount" (input)="onChange()" />
+          </label>
+        </div>
+      </div>
+      <p class="text-muted" style="margin-top:8px">
+        Asegúrate que la suma de aportes coincida con el total.
+      </p>
+    </form>
+    <div class="dialog__actions">
+      <button class="btn" type="button" (click)="cancel.emit()">Cancelar</button>
+      <button class="btn primary" type="button" (click)="apply()" [disabled]="!isValidSum()">Aplicar</button>
+    </div>
+  </div>
+</div>

--- a/Frontend/src/app/features/dashboard/items/split-modal.component.scss
+++ b/Frontend/src/app/features/dashboard/items/split-modal.component.scss
@@ -1,0 +1,61 @@
+.modal {
+  position: fixed;
+  inset: 0;
+}
+
+.backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(2px);
+}
+
+.dialog {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: min(92%, 560px);
+  background: var(--white);
+  border: 1px solid var(--base-80);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3);
+  box-shadow: var(--shadow-md);
+}
+
+.dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.dialog__header h3 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--base-00);
+}
+
+.dialog__body {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+}
+
+.icon {
+  background: transparent;
+  border: 0;
+  color: var(--base-40);
+}
+
+.split-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}

--- a/Frontend/src/app/features/dashboard/items/split-modal.component.ts
+++ b/Frontend/src/app/features/dashboard/items/split-modal.component.ts
@@ -1,0 +1,106 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormArray, FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { PaymentAssignment, PaymentSplit } from '../../../shared/models/payment-split.model';
+
+@Component({
+  selector: 'app-split-modal',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './split-modal.component.html',
+  styleUrl: './split-modal.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SplitModalComponent {
+  private readonly fb = inject(FormBuilder);
+
+  @Input() members: { userId: string; label: string }[] = [];
+  @Input() total = 0;
+  @Input() set initialSplit(split: PaymentSplit | null) {
+    if (split) {
+      this.assignments.clear();
+      split.assignments.forEach((a) =>
+        this.assignments.push(
+          this.fb.group({
+            userId: [a.userId],
+            label: [a.label ?? ''],
+            percentage: [a.percentage ?? null],
+            amount: [a.amount ?? null],
+          }),
+        ),
+      );
+      this.recalculate();
+    }
+  }
+
+  @Output() cancel = new EventEmitter<void>();
+  @Output() save = new EventEmitter<PaymentSplit>();
+
+  readonly form = this.fb.group({
+    assignments: this.fb.array([]),
+  });
+
+  get assignments(): FormArray {
+    return this.form.get('assignments') as FormArray;
+  }
+
+  ngOnInit(): void {
+    if (!this.assignments.length) {
+      this.members.forEach((m) =>
+        this.assignments.push(
+          this.fb.group({
+            userId: [m.userId],
+            label: [m.label],
+            percentage: [null],
+            amount: [null],
+          }),
+        ),
+      );
+    }
+  }
+
+  onChange(): void {
+    this.recalculate();
+  }
+
+  private recalculate(): void {
+    const total = this.total;
+    this.assignments.controls.forEach((ctrl) => {
+      const percentage = ctrl.get('percentage')?.value;
+      const amount = ctrl.get('amount')?.value;
+      let finalAmount = amount;
+      let finalPercentage = percentage;
+      if (percentage !== null && percentage !== '' && !isNaN(Number(percentage))) {
+        finalAmount = (Number(percentage) / 100) * total;
+        ctrl.get('amount')?.setValue(finalAmount, { emitEvent: false });
+      } else if (amount !== null && amount !== '' && !isNaN(Number(amount))) {
+        finalPercentage = total ? (Number(amount) / total) * 100 : 0;
+        ctrl.get('percentage')?.setValue(finalPercentage, { emitEvent: false });
+      }
+    });
+  }
+
+  isValidSum(): boolean {
+    const sum = this.assignments.controls.reduce(
+      (acc, ctrl) => acc + Number(ctrl.get('amount')?.value || 0),
+      0,
+    );
+    return Math.round(sum * 100) === Math.round(this.total * 100);
+  }
+
+  apply(): void {
+    this.recalculate();
+    if (!this.isValidSum()) {
+      return;
+    }
+    const assignments: PaymentAssignment[] = this.assignments.controls.map((ctrl) => ({
+      userId: ctrl.get('userId')?.value,
+      label: ctrl.get('label')?.value,
+      percentage: Number(ctrl.get('percentage')?.value) || 0,
+      amount: Number(ctrl.get('amount')?.value) || 0,
+      calculatedAmount: Number(ctrl.get('amount')?.value) || 0,
+    }));
+    this.save.emit({ assignments });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add split modal component for assigning payment amounts or percentages
- integrate payment split modal into items component
- validate and recalc split before sending to item service

## Testing
- `npm ci`
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689a5b6295908326acbe6e39dc75801d