### PR TITLE
Agrega eliminación de categorías con confirmación de ítems

### DIFF
--- a/Backend/src/application/use-cases/category/delete-category.usecase.ts
+++ b/Backend/src/application/use-cases/category/delete-category.usecase.ts
@@ -12,7 +12,7 @@ export class DeleteCategoryUseCase {
     const category = await this.categoryRepo.findById(categoryId);
     if (!category) return null;
     await this.categoryRepo.delete(categoryId);
-    await this.itemRepo.clearCategory(categoryId);
+    await this.itemRepo.deleteByCategory(categoryId);
     return category;
   }
 }

--- a/Backend/src/infrastructure/persistence/repositories/item.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/item.repository.ts
@@ -26,7 +26,7 @@ export class ItemRepository {
     await ItemModel.findByIdAndDelete(id);
   }
 
-  async clearCategory(categoryId: string): Promise<void> {
-    await ItemModel.updateMany({ categoryId }, { $unset: { categoryId: '' } });
+  async deleteByCategory(categoryId: string): Promise<void> {
+    await ItemModel.deleteMany({ categoryId });
   }
 }

--- a/Frontend/src/app/core/categories/category.service.ts
+++ b/Frontend/src/app/core/categories/category.service.ts
@@ -40,4 +40,13 @@ export class CategoryService {
       )
       .pipe(map(({ category }) => category));
   }
+
+  delete(categoryId: string): Observable<Category> {
+    const householdId = this.household.getHouseholdId();
+    return this.http
+      .delete<{ category: Category }>(
+        `/households/${householdId}/categories/${categoryId}`,
+      )
+      .pipe(map(({ category }) => category));
+  }
 }

--- a/Frontend/src/app/core/items/items.service.ts
+++ b/Frontend/src/app/core/items/items.service.ts
@@ -34,6 +34,12 @@ export class ItemsService {
       .pipe(map(({ items }) => items));
   }
 
+  listByCategory(categoryId: string): Observable<Item[]> {
+    return this.list().pipe(
+      map((items) => items.filter((i) => i.categoryId === categoryId)),
+    );
+  }
+
   create(payload: CreateItemPayload): Observable<Item> {
     const householdId = this.household.getHouseholdId();
     return this.http

--- a/Frontend/src/app/features/dashboard/categories/categories.component.html
+++ b/Frontend/src/app/features/dashboard/categories/categories.component.html
@@ -6,7 +6,10 @@
     <ul class="list" role="list">
       <li class="item glass-card" role="listitem" *ngFor="let cat of categories()">
         <div class="item__title">{{ cat.name }}</div>
-        <button class="btn btn-ghost" type="button" (click)="edit(cat)">Editar</button>
+        <div class="item__actions">
+          <button class="btn btn-ghost" type="button" (click)="edit(cat)">Editar</button>
+          <button class="btn btn-ghost" type="button" (click)="confirmDelete(cat)">Eliminar</button>
+        </div>
       </li>
     </ul>
   
@@ -26,4 +29,24 @@
       </button>
     </form>
   </section>
+
+  <div class="modal" [class.open]="showDeleteModal()">
+    <div class="backdrop" (click)="cancelDelete()"></div>
+    <div class="dialog glass card-pad" role="dialog" aria-modal="true" aria-label="Eliminar categoría">
+      <div class="dialog__header">
+        <h3>Eliminar categoría</h3>
+        <button class="icon" type="button" (click)="cancelDelete()" aria-label="Cerrar">✕</button>
+      </div>
+      <div class="dialog__body">
+        <p>Se eliminarán los siguientes ítems:</p>
+        <ul>
+          <li *ngFor="let item of itemsToDelete()">{{ item.name }}</li>
+        </ul>
+      </div>
+      <div class="dialog__actions">
+        <button class="btn btn-ghost" type="button" (click)="cancelDelete()">Cancelar</button>
+        <button class="btn btn-primary" type="button" (click)="deleteConfirmed()">Eliminar</button>
+      </div>
+    </div>
+  </div>
   

--- a/Frontend/src/app/features/dashboard/categories/categories.component.scss
+++ b/Frontend/src/app/features/dashboard/categories/categories.component.scss
@@ -28,9 +28,40 @@
   font-weight: 600;
   color: var(--ink-1);
 }
+.item__actions { display: flex; gap: var(--s-2); }
 
 .form-grid {
   display: grid;
   gap: var(--s-4);
 }
 .form-grid label { display: grid; gap: 6px; }
+
+.modal { position: fixed; inset: 0; display: none; z-index: 60; }
+.modal.open { display: block; }
+.backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15,23,42,.40);
+  backdrop-filter: saturate(var(--sat)) blur(2px);
+  -webkit-backdrop-filter: saturate(var(--sat)) blur(2px);
+}
+.dialog {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: min(92%, 480px);
+  max-height: 86dvh;
+  overflow: auto;
+  border-radius: var(--r-card);
+}
+.dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--s-3);
+}
+.dialog__header h3 { margin: 0; font-size: var(--fs-18); color: var(--ink-1); }
+.dialog__body { display: grid; gap: var(--s-3); }
+.dialog__actions { display: flex; justify-content: flex-end; gap: var(--s-3); margin-top: var(--s-4); }
+.icon { background: transparent; border: 0; color: var(--ink-3); cursor: pointer; }

--- a/Frontend/src/app/features/dashboard/categories/categories.component.ts
+++ b/Frontend/src/app/features/dashboard/categories/categories.component.ts
@@ -8,6 +8,8 @@ import { CommonModule } from "@angular/common";
 import { ReactiveFormsModule, FormBuilder, Validators } from "@angular/forms";
 import { CategoryService } from "../../../core/categories/category.service";
 import { Category } from "../../../shared/models/category.model";
+import { ItemsService } from "../../../core/items/items.service";
+import { Item } from "../../../shared/models/item.model";
 
 @Component({
   selector: "app-categories",
@@ -20,6 +22,7 @@ import { Category } from "../../../shared/models/category.model";
 export class CategoriesComponent {
   private readonly fb = inject(FormBuilder);
   private readonly categoryService = inject(CategoryService);
+  private readonly itemsService = inject(ItemsService);
 
   readonly categories = signal<Category[]>([]);
 
@@ -29,6 +32,9 @@ export class CategoriesComponent {
   });
 
   readonly editingId = signal<string | null>(null);
+  readonly showDeleteModal = signal(false);
+  readonly itemsToDelete = signal<Item[]>([]);
+  readonly deletingCategory = signal<Category | null>(null);
 
   constructor() {
     this.load();
@@ -43,6 +49,31 @@ export class CategoriesComponent {
     this.categoryForm.patchValue({
       name: cat.name,
       description: cat.description ?? "",
+    });
+  }
+
+  confirmDelete(cat: Category): void {
+    this.deletingCategory.set(cat);
+    this.itemsService
+      .listByCategory(cat.id)
+      .subscribe((items) => {
+        this.itemsToDelete.set(items);
+        this.showDeleteModal.set(true);
+      });
+  }
+
+  cancelDelete(): void {
+    this.showDeleteModal.set(false);
+    this.deletingCategory.set(null);
+    this.itemsToDelete.set([]);
+  }
+
+  deleteConfirmed(): void {
+    const cat = this.deletingCategory();
+    if (!cat) return;
+    this.categoryService.delete(cat.id).subscribe(() => {
+      this.categories.update((list) => list.filter((c) => c.id !== cat.id));
+      this.cancelDelete();
     });
   }
 


### PR DESCRIPTION
## Summary
- Delete category items when removing a category in backend
- Allow users to delete a category and view associated items in a confirmation modal

## Testing
- `npm run build` (Backend)
- `npm run lint` (Backend)
- `npm test` (Backend)
- `npm run build` (Frontend)
- `npm run lint` (Frontend) *(fails: Missing script "lint")*
- `npm test` (Frontend) *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689aade066148326a2d950a3ae44f019