### PR TITLE
Implement household member listing and dynamic payment splits

### DIFF
--- a/Backend/src/application/__tests__/list-household-members.usecase.spec.ts
+++ b/Backend/src/application/__tests__/list-household-members.usecase.spec.ts
@@ -1,0 +1,67 @@
+/* eslint-env jest */
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { HouseholdMembershipRepository } from '../../infrastructure/persistence/repositories/household-membership.repository';
+import { ListHouseholdMembersUseCase } from '../use-cases/household/list-members.usecase';
+import { MembershipRole } from '../../domain/models/enums/membership-role.enum';
+import { MembershipStatus } from '../../domain/models/enums/membership-status.enum';
+
+describe('ListHouseholdMembersUseCase', () => {
+  let mongo: MongoMemoryServer;
+  let repo: HouseholdMembershipRepository;
+  let listMembers: ListHouseholdMembersUseCase;
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create();
+    await mongoose.connect(mongo.getUri());
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongo.stop();
+  });
+
+  beforeEach(async () => {
+    await mongoose.connection.db.dropDatabase();
+    repo = new HouseholdMembershipRepository();
+    listMembers = new ListHouseholdMembersUseCase(repo);
+  });
+
+  it('returns active members for a household', async () => {
+    const householdId = 'h1';
+    await repo.create({
+      userId: 'u1',
+      householdId,
+      role: MembershipRole.ADMIN,
+      status: MembershipStatus.ACTIVE,
+      joinedAt: new Date(),
+    });
+    await repo.create({
+      userId: 'u2',
+      householdId,
+      role: MembershipRole.MEMBER,
+      status: MembershipStatus.ACTIVE,
+      joinedAt: new Date(),
+    });
+    await repo.create({
+      userId: 'u3',
+      householdId: 'h2',
+      role: MembershipRole.MEMBER,
+      status: MembershipStatus.ACTIVE,
+      joinedAt: new Date(),
+    });
+    await repo.create({
+      userId: 'u4',
+      householdId,
+      role: MembershipRole.MEMBER,
+      status: MembershipStatus.REVOKED,
+      joinedAt: new Date(),
+    });
+
+    const members = await listMembers.execute(householdId);
+    expect(members).toHaveLength(2);
+    expect(members.map((m) => m.userId)).toEqual(
+      expect.arrayContaining(['u1', 'u2']),
+    );
+  });
+});

--- a/Backend/src/application/use-cases/household/list-members.usecase.ts
+++ b/Backend/src/application/use-cases/household/list-members.usecase.ts
@@ -1,0 +1,10 @@
+import { HouseholdMembership } from '../../../domain/models/household-membership.model';
+import { HouseholdMembershipRepository } from '../../../infrastructure/persistence/repositories/household-membership.repository';
+
+export class ListHouseholdMembersUseCase {
+  constructor(private membershipRepo: HouseholdMembershipRepository) {}
+
+  async execute(householdId: string): Promise<HouseholdMembership[]> {
+    return await this.membershipRepo.findActiveByHousehold(householdId);
+  }
+}

--- a/Backend/src/infrastructure/persistence/repositories/household-membership.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/household-membership.repository.ts
@@ -42,6 +42,16 @@ export class HouseholdMembershipRepository {
     return docs.map((doc) => this.toDomain(doc));
   }
 
+  async findActiveByHousehold(
+    householdId: string,
+  ): Promise<HouseholdMembership[]> {
+    const docs = await HouseholdMembershipModel.find({
+      householdId,
+      status: MembershipStatus.ACTIVE,
+    }).lean<MembershipRecord[]>();
+    return docs.map((doc) => this.toDomain(doc));
+  }
+
   async updateStatus(
     id: string,
     status: MembershipStatus,

--- a/Backend/src/interfaces/http/controllers/household.controller.ts
+++ b/Backend/src/interfaces/http/controllers/household.controller.ts
@@ -4,6 +4,7 @@ import { InviteToHouseholdUseCase } from '../../../application/use-cases/househo
 import { RevokeMembershipUseCase } from '../../../application/use-cases/household/revoke-membership.usecase';
 import { CancelInvitationUseCase } from '../../../application/use-cases/household/cancel-invitation.usecase';
 import { GetHouseholdUseCase } from '../../../application/use-cases/household/get-household.usecase';
+import { ListHouseholdMembersUseCase } from '../../../application/use-cases/household/list-members.usecase';
 import { NotFoundError } from '../../../domain/errors/not-found.error';
 import {
   CreateHouseholdRequestDto,
@@ -21,6 +22,7 @@ export class HouseholdController {
     private revokeMembership: RevokeMembershipUseCase,
     private cancelInvitationUseCase: CancelInvitationUseCase,
     private getHousehold: GetHouseholdUseCase,
+    private listMembersUseCase: ListHouseholdMembersUseCase,
   ) {}
 
   create = async (req: Request, res: Response) => {
@@ -77,5 +79,11 @@ export class HouseholdController {
       throw new NotFoundError('Household not found');
     }
     res.json({ household });
+  };
+
+  listMembers = async (req: Request, res: Response) => {
+    const { householdId } = req.params as { householdId: string };
+    const members = await this.listMembersUseCase.execute(householdId);
+    res.json({ members });
   };
 }

--- a/Backend/src/interfaces/http/routes/household.routes.ts
+++ b/Backend/src/interfaces/http/routes/household.routes.ts
@@ -11,6 +11,7 @@ import { InviteToHouseholdUseCase } from '../../../application/use-cases/househo
 import { RevokeMembershipUseCase } from '../../../application/use-cases/household/revoke-membership.usecase';
 import { CancelInvitationUseCase } from '../../../application/use-cases/household/cancel-invitation.usecase';
 import { GetHouseholdUseCase } from '../../../application/use-cases/household/get-household.usecase';
+import { ListHouseholdMembersUseCase } from '../../../application/use-cases/household/list-members.usecase';
 import { EmailService } from '../../../infrastructure/notifications/email.service';
 import { validate } from '../../middleware/validation.middleware';
 import { createHouseholdSchema, inviteSchema } from '../dto/household.dto';
@@ -41,6 +42,7 @@ const cancelInvitation = new CancelInvitationUseCase(
   userRepo,
 );
 const getHousehold = new GetHouseholdUseCase(householdRepo);
+const listMembers = new ListHouseholdMembersUseCase(membershipRepo);
 
 const controller = new HouseholdController(
   createHousehold,
@@ -48,6 +50,7 @@ const controller = new HouseholdController(
   revokeMembership,
   cancelInvitation,
   getHousehold,
+  listMembers,
 );
 
 router.post(
@@ -57,6 +60,11 @@ router.post(
   controller.create,
 );
 router.get('/:householdId', authMiddleware(jwtService), controller.get);
+router.get(
+  '/:householdId/members',
+  authMiddleware(jwtService),
+  controller.listMembers,
+);
 router.post(
   '/:householdId/invitations',
   authMiddleware(jwtService),

--- a/Frontend/src/app/core/household/household.service.ts
+++ b/Frontend/src/app/core/household/household.service.ts
@@ -55,6 +55,15 @@ export class HouseholdService {
       .pipe(map(({ memberships }) => memberships));
   }
 
+  getMembers(): Observable<HouseholdMembership[]> {
+    const householdId = this.getHouseholdId();
+    return this.http
+      .get<{ members: HouseholdMembership[] }>(
+        `/households/${householdId}/members`
+      )
+      .pipe(map(({ members }) => members));
+  }
+
   getUserHouseholds(): Observable<Household[]> {
     return this.getUserMemberships().pipe(
       switchMap((memberships) => {

--- a/Frontend/src/app/features/dashboard/items/items.component.html
+++ b/Frontend/src/app/features/dashboard/items/items.component.html
@@ -58,7 +58,12 @@
         </header>
   
         <footer class="item__footer">
-          <div class="split">50% tú • 50% pareja</div>
+          <div class="split" *ngIf="item.paymentSplit">
+            <ng-container *ngFor="let a of item.paymentSplit.assignments; let last = last">
+              {{ a.percentage | number: '1.0-2' }}% {{ a.label || a.userId }}
+              ({{ a.calculatedAmount | currencyFormat }} {{ item.currency }})<span *ngIf="!last"> • </span>
+            </ng-container>
+          </div>
           <div class="tags">
             <span class="tag">{{ 'Prioridad: ' + getPriorityLabel(item.priority) }}</span>
             <button class="btn btn-ghost" type="button" (click)="edit(item)">Editar</button>
@@ -143,7 +148,7 @@
   
   <app-split-modal
     *ngIf="showSplitModal()"
-    [members]="members"
+    [members]="members()"
     [total]="itemForm.get('price')?.value || 0"
     [initialSplit]="paymentSplit()"
     (cancel)="showSplitModal.set(false)"


### PR DESCRIPTION
## Summary
- expose active members of a household via new `/households/:id/members` endpoint
- fetch household members in items page and send real userIds in split payments
- show split percentages with monetary amounts per member

## Testing
- `npm test` (backend)
- `npm run lint` (backend)
- `npm run build` (backend)
- `npm test` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)* (frontend)
- `npm run lint` *(fails: Missing script: "lint")* (frontend)
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689b6f2135608326ba9c0c5533b3d848