### PR TITLE
Include user name in JWT tokens

### DIFF
--- a/Backend/src/application/use-cases/budget/update-budget-goal.usecase.ts
+++ b/Backend/src/application/use-cases/budget/update-budget-goal.usecase.ts
@@ -23,6 +23,7 @@ export class UpdateBudgetGoalUseCase {
     householdId: string,
     type: BudgetGoalType,
     payload: UpdateBudgetGoalPayload,
+    userName?: string,
   ): Promise<Household | null> {
     const household = await this.householdRepo.findById(householdId);
     if (!household) return null;
@@ -62,6 +63,7 @@ export class UpdateBudgetGoalUseCase {
       occurredOn: timestamp,
       householdId,
       userId,
+      ...(userName ? { userName } : {}),
       goalType: type,
       previousAmount,
       newAmount: payload.amount,

--- a/Backend/src/infrastructure/auth/jwt.service.ts
+++ b/Backend/src/infrastructure/auth/jwt.service.ts
@@ -2,41 +2,54 @@ import jwt from 'jsonwebtoken';
 import { config } from '../../config/env';
 
 export class JwtService {
-  signAccess(userId: string): string {
-    return jwt.sign({ sub: userId }, config.jwtSecret, { expiresIn: '15m' });
+  signAccess(userId: string, userName: string): string {
+    return jwt.sign({ sub: userId, name: userName }, config.jwtSecret, {
+      expiresIn: '15m',
+    });
   }
 
   signRefresh(
-    payload: { userId: string; jti: string; familyId: string },
+    payload: {
+      userId: string;
+      userName: string;
+      jti: string;
+      familyId: string;
+    },
     expiresIn: string | number = '7d',
   ): string {
-    const { userId, jti, familyId } = payload;
+    const { userId, userName, jti, familyId } = payload;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (jwt.sign as any)(
-      { sub: userId, jti, familyId },
+      { sub: userId, name: userName, jti, familyId },
       config.jwtRefreshSecret,
       { expiresIn },
     );
   }
 
-  verifyAccess(token: string): { userId: string } {
-    const decoded = jwt.verify(token, config.jwtSecret) as { sub: string };
-    return { userId: decoded.sub };
+  verifyAccess(token: string): { userId: string; userName: string } {
+    const decoded = jwt.verify(token, config.jwtSecret) as {
+      sub: string;
+      name: string;
+    };
+    return { userId: decoded.sub, userName: decoded.name };
   }
 
   verifyRefresh(token: string): {
     userId: string;
+    userName: string;
     jti: string;
     familyId: string;
   } {
     const decoded = jwt.verify(token, config.jwtRefreshSecret) as {
       sub: string;
+      name: string;
       jti: string;
       familyId: string;
     };
     return {
       userId: decoded.sub,
+      userName: decoded.name,
       jti: decoded.jti,
       familyId: decoded.familyId,
     };

--- a/Backend/src/infrastructure/events/changelog.subscriber.ts
+++ b/Backend/src/infrastructure/events/changelog.subscriber.ts
@@ -20,7 +20,7 @@ domainEventBus.subscribe<ItemCreatedEvent>('ItemCreated', async (event) => {
     description: `Item ${event.item.name} created`,
     diff: { after: event.item },
     userId: event.userId,
-    userName: event.userName ?? '',
+    userName: event.userName || 'Unknown',
     timestamp: event.occurredOn,
   });
 });
@@ -34,7 +34,7 @@ domainEventBus.subscribe<ItemUpdatedEvent>('ItemUpdated', async (event) => {
     description: `Item ${event.after.name} updated`,
     diff: { before: event.before, after: event.after },
     userId: event.userId,
-    userName: event.userName ?? '',
+    userName: event.userName || 'Unknown',
     timestamp: event.occurredOn,
   });
 });
@@ -48,7 +48,7 @@ domainEventBus.subscribe<ItemDeletedEvent>('ItemDeleted', async (event) => {
     description: `Item ${event.item.name} deleted`,
     diff: { before: event.item },
     userId: event.userId,
-    userName: event.userName ?? '',
+    userName: event.userName || 'Unknown',
     timestamp: event.occurredOn,
   });
 });
@@ -68,7 +68,7 @@ domainEventBus.subscribe<BudgetGoalUpdatedEvent>(
         type: event.goalType,
       },
       userId: event.userId,
-      userName: event.userName ?? '',
+      userName: event.userName || 'Unknown',
       timestamp: event.occurredOn,
     });
   },

--- a/Backend/src/interfaces/http/controllers/auth.controller.ts
+++ b/Backend/src/interfaces/http/controllers/auth.controller.ts
@@ -55,6 +55,7 @@ export class AuthController {
     );
     const { accessToken, refreshToken } = await this.refreshTokenService.issue(
       user.id,
+      user.fullName,
     );
     res.cookie('refreshToken', refreshToken, this.cookieOptions);
     res.json({ user: toPublicUser(user), accessToken });
@@ -65,6 +66,7 @@ export class AuthController {
     const { user } = await this.loginUser.execute(email, password);
     const { accessToken, refreshToken } = await this.refreshTokenService.issue(
       user.id,
+      user.fullName,
     );
     res.cookie('refreshToken', refreshToken, this.cookieOptions);
     res.json({ user: toPublicUser(user), accessToken });
@@ -75,6 +77,7 @@ export class AuthController {
     const { user } = await this.googleAuth.execute(idToken);
     const { accessToken, refreshToken } = await this.refreshTokenService.issue(
       user.id,
+      user.fullName,
     );
     res.cookie('refreshToken', refreshToken, this.cookieOptions);
     res.json({ user: toPublicUser(user), accessToken });
@@ -97,7 +100,7 @@ export class AuthController {
     try {
       const { user } = await this.oauthLogin.execute(code);
       const { accessToken, refreshToken } =
-        await this.refreshTokenService.issue(user.id);
+        await this.refreshTokenService.issue(user.id, user.fullName);
       res.cookie('refreshToken', refreshToken, this.cookieOptions);
       redirectUrl.searchParams.set('token', accessToken);
       redirectUrl.searchParams.set('user', JSON.stringify(toPublicUser(user)));

--- a/Backend/src/interfaces/http/controllers/budget.controller.ts
+++ b/Backend/src/interfaces/http/controllers/budget.controller.ts
@@ -11,6 +11,7 @@ import { NotFoundError } from '../../../domain/errors/not-found.error';
 
 interface AuthRequest extends Request {
   userId: string;
+  userName: string;
 }
 
 export class BudgetController {
@@ -33,7 +34,7 @@ export class BudgetController {
       householdId: string;
       type: BudgetGoalType;
     };
-    const userId = (req as AuthRequest).userId;
+    const { userId, userName } = req as AuthRequest;
     const payload = req.body as UpdateBudgetRequestDto;
     const updatePayload: UpdateBudgetGoalPayload = { amount: payload.amount };
     if (payload.targetDate) {
@@ -47,6 +48,7 @@ export class BudgetController {
       householdId,
       type,
       updatePayload,
+      userName,
     );
     if (!result) {
       throw new NotFoundError('Household not found');

--- a/Backend/src/interfaces/http/controllers/item.controller.ts
+++ b/Backend/src/interfaces/http/controllers/item.controller.ts
@@ -15,6 +15,7 @@ import { NotFoundError } from '../../../domain/errors/not-found.error';
 
 interface AuthRequest extends Request {
   userId: string;
+  userName: string;
 }
 
 export class ItemController {
@@ -33,26 +34,24 @@ export class ItemController {
 
   create = async (req: Request, res: Response) => {
     const { householdId } = req.params as { householdId: string };
-    const userId = (req as AuthRequest).userId;
+    const { userId, userName } = req as AuthRequest;
     const payload = req.body as CreateItemRequestDto;
-    const item = await this.createItem.execute(
-      userId,
-      householdId,
-      payload as CreateItemPayload,
-    );
+    const item = await this.createItem.execute(userId, householdId, {
+      ...payload,
+      lastModifiedByName: userName,
+    } as CreateItemPayload);
     notifyHousehold(householdId, 'item:created', item);
     res.status(201).json({ item });
   };
 
   update = async (req: Request, res: Response) => {
     const { itemId } = req.params as { itemId: string };
-    const userId = (req as AuthRequest).userId;
+    const { userId, userName } = req as AuthRequest;
     const payload = req.body as UpdateItemRequestDto;
-    const item = await this.updateItem.execute(
-      userId,
-      itemId,
-      payload as UpdateItemPayload,
-    );
+    const item = await this.updateItem.execute(userId, itemId, {
+      ...payload,
+      lastModifiedByName: userName,
+    } as UpdateItemPayload);
     if (!item) {
       throw new NotFoundError('Item not found');
     }
@@ -62,8 +61,8 @@ export class ItemController {
 
   delete = async (req: Request, res: Response) => {
     const { itemId } = req.params as { itemId: string };
-    const userId = (req as AuthRequest).userId;
-    const item = await this.deleteItem.execute(userId, itemId);
+    const { userId, userName } = req as AuthRequest;
+    const item = await this.deleteItem.execute(userId, itemId, userName);
     if (!item) {
       throw new NotFoundError('Item not found');
     }

--- a/Backend/src/interfaces/middleware/auth.middleware.ts
+++ b/Backend/src/interfaces/middleware/auth.middleware.ts
@@ -21,7 +21,10 @@ export const authMiddleware =
     }
     try {
       const payload = jwtService.verifyAccess(token);
-      (req as Request & { userId: string }).userId = payload.userId;
+      (req as Request & { userId: string; userName: string }).userId =
+        payload.userId;
+      (req as Request & { userId: string; userName: string }).userName =
+        payload.userName;
       next();
     } catch {
       res.status(401).json({ error: 'No autorizado' });


### PR DESCRIPTION
## Summary
- add user name to access and refresh JWTs
- propagate decoded user name through middleware and controllers
- default changelog user name when events omit it

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ba91afc048326a338eac3f9c24cea