### PR TITLE
Ensure item repository returns id property

### DIFF
--- a/Backend/src/infrastructure/persistence/repositories/item.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/item.repository.ts
@@ -3,11 +3,15 @@ import { ItemModel } from '../models/item.schema';
 
 export class ItemRepository {
   async findById(id: string): Promise<Item | null> {
-    return (await ItemModel.findById(id).lean()) as Item | null;
+    const doc = await ItemModel.findById(id).lean();
+    return doc ? ({ id: doc._id.toString(), ...doc } as unknown as Item) : null;
   }
 
   async findByHousehold(householdId: string): Promise<Item[]> {
-    return (await ItemModel.find({ householdId }).lean()) as Item[];
+    const docs = await ItemModel.find({ householdId }).lean();
+    return docs.map(
+      (doc) => ({ id: doc._id.toString(), ...doc }) as unknown as Item,
+    );
   }
 
   async create(item: Omit<Item, 'id'>): Promise<Item> {
@@ -19,7 +23,9 @@ export class ItemRepository {
     const updated = await ItemModel.findByIdAndUpdate(id, update, {
       new: true,
     }).lean();
-    return updated as Item | null;
+    return updated
+      ? ({ id: updated._id.toString(), ...updated } as unknown as Item)
+      : null;
   }
 
   async delete(id: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Return `id` in `findById`, `findByHousehold`, and `update` methods of the item repository
- Confirmed item routes propagate items with their `id`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bafccb0c083269769406314d36272