### PR TITLE
Add item deletion support

### DIFF
--- a/Backend/src/application/__tests__/delete-item.usecase.spec.ts
+++ b/Backend/src/application/__tests__/delete-item.usecase.spec.ts
@@ -1,0 +1,61 @@
+/* eslint-env jest */
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { ItemRepository } from '../../infrastructure/persistence/repositories/item.repository';
+import { DeleteItemUseCase } from '../use-cases/item/delete-item.usecase';
+import { ItemType } from '../../domain/models/enums/item-type.enum';
+import { DomainEventBus } from '../../domain/events/domain-event-bus.interface';
+
+describe('DeleteItemUseCase', () => {
+  let mongo: MongoMemoryServer;
+  let repo: ItemRepository;
+  let eventBus: DomainEventBus & {
+    publish: jest.Mock;
+    subscribe: jest.Mock;
+  };
+  let usecase: DeleteItemUseCase;
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create();
+    await mongoose.connect(mongo.getUri());
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongo.stop();
+  });
+
+  beforeEach(async () => {
+    await mongoose.connection.db.dropDatabase();
+    repo = new ItemRepository();
+    eventBus = {
+      publish: jest.fn().mockResolvedValue(undefined),
+      subscribe: jest.fn(),
+    };
+    usecase = new DeleteItemUseCase(repo, eventBus);
+  });
+
+  it('removes item and publishes event', async () => {
+    const created = await repo.create({
+      householdId: 'h1',
+      name: 'Test',
+      type: ItemType.ONE_TIME,
+      price: 100,
+      currency: 'USD',
+      lastModifiedBy: 'u1',
+    });
+
+    const deleted = await usecase.execute('u1', created.id, 'User');
+
+    expect(deleted?.id).toBe(created.id);
+    const found = await repo.findById(created.id);
+    expect(found).toBeNull();
+    expect(eventBus.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'ItemDeleted',
+        householdId: 'h1',
+        userId: 'u1',
+      }),
+    );
+  });
+});

--- a/Backend/src/infrastructure/persistence/repositories/item.repository.ts
+++ b/Backend/src/infrastructure/persistence/repositories/item.repository.ts
@@ -3,11 +3,22 @@ import { ItemModel } from '../models/item.schema';
 
 export class ItemRepository {
   async findById(id: string): Promise<Item | null> {
-    return (await ItemModel.findById(id).lean()) as Item | null;
+    const doc = await ItemModel.findById(id).lean();
+    if (!doc) return null;
+    const { _id, ...data } = doc as {
+      _id: unknown;
+    } & Record<string, unknown>;
+    return { id: String(_id), ...data } as Item;
   }
 
   async findByHousehold(householdId: string): Promise<Item[]> {
-    return (await ItemModel.find({ householdId }).lean()) as Item[];
+    const docs = await ItemModel.find({ householdId }).lean();
+    return docs.map((doc) => {
+      const { _id, ...data } = doc as {
+        _id: unknown;
+      } & Record<string, unknown>;
+      return { id: String(_id), ...data } as Item;
+    });
   }
 
   async create(item: Omit<Item, 'id'>): Promise<Item> {
@@ -19,7 +30,11 @@ export class ItemRepository {
     const updated = await ItemModel.findByIdAndUpdate(id, update, {
       new: true,
     }).lean();
-    return updated as Item | null;
+    if (!updated) return null;
+    const { _id, ...data } = updated as {
+      _id: unknown;
+    } & Record<string, unknown>;
+    return { id: String(_id), ...data } as Item;
   }
 
   async delete(id: string): Promise<void> {

--- a/Frontend/src/app/core/items/items.service.ts
+++ b/Frontend/src/app/core/items/items.service.ts
@@ -56,4 +56,11 @@ export class ItemsService {
       )
       .pipe(map(({ item }) => item));
   }
+
+  delete(itemId: string): Observable<void> {
+    const householdId = this.household.getHouseholdId();
+    return this.http.delete<void>(
+      `/households/${householdId}/items/${itemId}`,
+    );
+  }
 }

--- a/Frontend/src/app/features/dashboard/items/items.component.html
+++ b/Frontend/src/app/features/dashboard/items/items.component.html
@@ -67,6 +67,7 @@
           <div class="tags">
             <span class="tag">{{ 'Prioridad: ' + getPriorityLabel(item.priority) }}</span>
             <button class="btn btn-ghost" type="button" (click)="edit(item)">Editar</button>
+            <button class="btn btn-ghost" type="button" (click)="delete(item)">Eliminar</button>
           </div>
         </footer>
       </article>

--- a/Frontend/src/app/features/dashboard/items/items.component.ts
+++ b/Frontend/src/app/features/dashboard/items/items.component.ts
@@ -146,6 +146,12 @@ export class ItemsComponent {
     this.paymentSplit.set(item.paymentSplit ?? null);
   }
 
+  delete(item: Item): void {
+    this.itemsService.delete(item.id).subscribe(() => {
+      this.items.update((list) => list.filter((i) => i.id !== item.id));
+    });
+  }
+
   getCategoryName(id?: string): string {
     const cat = this.categories().find((c) => c.id === id);
     return cat ? cat.name : "";


### PR DESCRIPTION
## Summary
- allow backend repository to return id fields consistently
- add API to delete items in frontend service and component
- cover item deletion use case with unit tests

## Testing
- `npm test` (backend)
- `npm run lint` (backend)
- `npm run build` (backend)
- `npm test` (frontend) *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` (frontend) *(fails: Missing script: "lint")*
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689baeab4aac8326b31db2d1313853cf