### PR TITLE
Refresh tokens on any 401 error

### DIFF
--- a/Frontend/src/app/core/interceptors/auth-http.interceptor.spec.ts
+++ b/Frontend/src/app/core/interceptors/auth-http.interceptor.spec.ts
@@ -44,9 +44,9 @@ describe('authHttpInterceptor', () => {
     localStorage.clear();
   });
 
-  it('refreshes the token once and retries queued requests', (done) => {
-    const expired = Math.floor(Date.now() / 1000) - 10;
-    (auth as any).accessToken = createToken(expired);
+  it('refreshes the token once and retries queued requests when the token is not expired', (done) => {
+    const valid = Math.floor(Date.now() / 1000) + 3600;
+    (auth as any).accessToken = createToken(valid);
 
     const responses: string[] = [];
     http.get<string>('/data').subscribe((r) => responses.push(r));
@@ -76,9 +76,9 @@ describe('authHttpInterceptor', () => {
     retry2.flush('ok2');
   });
 
-  it('redirects to login when token refresh fails', (done) => {
-    const expired = Math.floor(Date.now() / 1000) - 10;
-    (auth as any).accessToken = createToken(expired);
+  it('redirects to login when token refresh fails even if the token is not expired', (done) => {
+    const valid = Math.floor(Date.now() / 1000) + 3600;
+    (auth as any).accessToken = createToken(valid);
 
     http.get('/data').subscribe({
       error: (err) => {

--- a/Frontend/src/app/core/interceptors/auth-http.interceptor.ts
+++ b/Frontend/src/app/core/interceptors/auth-http.interceptor.ts
@@ -25,8 +25,7 @@ export const authHttpInterceptor: HttpInterceptorFn = (req, next) => {
       if (
         error.status === 401 &&
         token &&
-        !req.url.includes('/auth/refresh') &&
-        auth.isTokenExpired(token)
+        !req.url.includes('/auth/refresh')
       ) {
         return handle401(req, next, auth);
       }


### PR DESCRIPTION
## Summary
- Retry requests on 401 responses whenever a token exists, regardless of expiration
- Test refresh and retry flow even when the token has not expired

## Testing
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_689bd44893748326946eab7a2597de9c