### PR TITLE
Sync category updates across components

### DIFF
--- a/Frontend/src/app/core/categories/category.service.ts
+++ b/Frontend/src/app/core/categories/category.service.ts
@@ -1,6 +1,6 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { map, Observable } from 'rxjs';
+import { map, Observable, tap } from 'rxjs';
 import { HouseholdService } from '../household/household.service';
 import { Category } from '../../shared/models/category.model';
 
@@ -13,12 +13,18 @@ export type UpdateCategoryPayload = CreateCategoryPayload;
 export class CategoryService {
   private readonly http = inject(HttpClient);
   private readonly household = inject(HouseholdService);
+  private readonly categoriesSignal = signal<Category[]>([]);
+
+  readonly categories = this.categoriesSignal.asReadonly();
 
   list(): Observable<Category[]> {
     const householdId = this.household.getHouseholdId();
     return this.http
       .get<{ categories: Category[] }>(`/households/${householdId}/categories`)
-      .pipe(map(({ categories }) => categories));
+      .pipe(
+        map(({ categories }) => categories),
+        tap((cats) => this.categoriesSignal.set(cats)),
+      );
   }
 
   create(payload: CreateCategoryPayload): Observable<Category> {
@@ -28,17 +34,32 @@ export class CategoryService {
         `/households/${householdId}/categories`,
         payload,
       )
-      .pipe(map(({ category }) => category));
+      .pipe(
+        map(({ category }) => category),
+        tap((created) =>
+          this.categoriesSignal.update((list) => [...list, created]),
+        ),
+      );
   }
 
-  update(categoryId: string, payload: UpdateCategoryPayload): Observable<Category> {
+  update(
+    categoryId: string,
+    payload: UpdateCategoryPayload,
+  ): Observable<Category> {
     const householdId = this.household.getHouseholdId();
     return this.http
       .put<{ category: Category }>(
         `/households/${householdId}/categories/${categoryId}`,
         payload,
       )
-      .pipe(map(({ category }) => category));
+      .pipe(
+        map(({ category }) => category),
+        tap((updated) =>
+          this.categoriesSignal.update((list) =>
+            list.map((c) => (c.id === updated.id ? updated : c)),
+          ),
+        ),
+      );
   }
 
   delete(categoryId: string): Observable<Category> {
@@ -47,6 +68,13 @@ export class CategoryService {
       .delete<{ category: Category }>(
         `/households/${householdId}/categories/${categoryId}`,
       )
-      .pipe(map(({ category }) => category));
+      .pipe(
+        map(({ category }) => category),
+        tap((removed) =>
+          this.categoriesSignal.update((list) =>
+            list.filter((c) => c.id !== removed.id),
+          ),
+        ),
+      );
   }
 }

--- a/Frontend/src/app/features/dashboard/categories/categories.component.ts
+++ b/Frontend/src/app/features/dashboard/categories/categories.component.ts
@@ -24,7 +24,7 @@ export class CategoriesComponent {
   private readonly categoryService = inject(CategoryService);
   private readonly itemsService = inject(ItemsService);
 
-  readonly categories = signal<Category[]>([]);
+  readonly categories = this.categoryService.categories;
 
   readonly categoryForm = this.fb.nonNullable.group({
     name: ["", Validators.required],
@@ -41,7 +41,7 @@ export class CategoriesComponent {
   }
 
   load(): void {
-    this.categoryService.list().subscribe((cats) => this.categories.set(cats));
+    this.categoryService.list().subscribe();
   }
 
   edit(cat: Category): void {
@@ -72,7 +72,6 @@ export class CategoriesComponent {
     const cat = this.deletingCategory();
     if (!cat) return;
     this.categoryService.delete(cat.id).subscribe(() => {
-      this.categories.update((list) => list.filter((c) => c.id !== cat.id));
       this.cancelDelete();
     });
   }
@@ -84,16 +83,12 @@ export class CategoriesComponent {
     const data = this.categoryForm.getRawValue();
     const id = this.editingId();
     if (id) {
-      this.categoryService.update(id, data).subscribe((updated) => {
-        this.categories.update((list) =>
-          list.map((c) => (c.id === updated.id ? updated : c))
-        );
+      this.categoryService.update(id, data).subscribe(() => {
         this.categoryForm.reset();
         this.editingId.set(null);
       });
     } else {
-      this.categoryService.create(data).subscribe((created) => {
-        this.categories.update((list) => [...list, created]);
+      this.categoryService.create(data).subscribe(() => {
         this.categoryForm.reset();
       });
     }

--- a/Frontend/src/app/features/dashboard/items/items.component.ts
+++ b/Frontend/src/app/features/dashboard/items/items.component.ts
@@ -12,7 +12,6 @@ import { CurrencyFormatPipe } from "../../../shared/pipes/currency-format.pipe";
 import { ItemsService } from "../../../core/items/items.service";
 import { CategoryService } from "../../../core/categories/category.service";
 import { Item } from "../../../shared/models/item.model";
-import { Category } from "../../../shared/models/category.model";
 import { ItemType } from "../../../shared/models/item-type.enum";
 import { ItemPriority } from "../../../shared/models/item-priority.enum";
 import { ItemStatus } from "../../../shared/models/item-status.enum";
@@ -53,7 +52,7 @@ export class ItemsComponent {
   private readonly householdService = inject(HouseholdService);
 
   readonly items = signal<Item[]>([]);
-  readonly categories = signal<Category[]>([]);
+  readonly categories = this.categoryService.categories;
   readonly currencies$ = this.currencyService.getSupported();
 
   private defaultCurrency = "USD";
@@ -130,7 +129,7 @@ export class ItemsComponent {
 
   load(): void {
     this.itemsService.list().subscribe((items) => this.items.set(items));
-    this.categoryService.list().subscribe((cats) => this.categories.set(cats));
+    this.categoryService.list().subscribe();
   }
 
   setFilter(filter: ItemFilter): void {


### PR DESCRIPTION
## Summary
- share categories via signal in CategoryService and update on CRUD operations
- consume service signal in category and item components to reflect edits instantly

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_689bde05a8f883269df0ee58b9b6d704