### PR TITLE
Mostrar nombre de usuario en división de ítems

### DIFF
--- a/Backend/src/application/use-cases/household/list-members.usecase.ts
+++ b/Backend/src/application/use-cases/household/list-members.usecase.ts
@@ -1,10 +1,26 @@
 import { HouseholdMembership } from '../../../domain/models/household-membership.model';
 import { HouseholdMembershipRepository } from '../../../infrastructure/persistence/repositories/household-membership.repository';
+import { UserRepository } from '../../../infrastructure/persistence/repositories/user.repository';
+
+export interface HouseholdMember extends HouseholdMembership {
+  fullName: string;
+}
 
 export class ListHouseholdMembersUseCase {
-  constructor(private membershipRepo: HouseholdMembershipRepository) {}
+  constructor(
+    private membershipRepo: HouseholdMembershipRepository,
+    private userRepo: UserRepository,
+  ) {}
 
-  async execute(householdId: string): Promise<HouseholdMembership[]> {
-    return await this.membershipRepo.findActiveByHousehold(householdId);
+  async execute(householdId: string): Promise<HouseholdMember[]> {
+    const memberships =
+      await this.membershipRepo.findActiveByHousehold(householdId);
+    const users = await Promise.all(
+      memberships.map((m) => this.userRepo.findById(m.userId)),
+    );
+    return memberships.map((m, idx) => ({
+      ...m,
+      fullName: users[idx]?.fullName ?? '',
+    }));
   }
 }

--- a/Backend/src/interfaces/http/routes/household.routes.ts
+++ b/Backend/src/interfaces/http/routes/household.routes.ts
@@ -42,7 +42,7 @@ const cancelInvitation = new CancelInvitationUseCase(
   userRepo,
 );
 const getHousehold = new GetHouseholdUseCase(householdRepo);
-const listMembers = new ListHouseholdMembersUseCase(membershipRepo);
+const listMembers = new ListHouseholdMembersUseCase(membershipRepo, userRepo);
 
 const controller = new HouseholdController(
   createHousehold,

--- a/Frontend/src/app/core/household/household.service.ts
+++ b/Frontend/src/app/core/household/household.service.ts
@@ -31,6 +31,7 @@ export interface HouseholdMembership {
   status: "pending" | "active" | "revoked";
   joinedAt: string;
   invitedBy?: string;
+  fullName?: string;
 }
 
 @Injectable({ providedIn: "root" })

--- a/Frontend/src/app/features/dashboard/items/items.component.ts
+++ b/Frontend/src/app/features/dashboard/items/items.component.ts
@@ -121,7 +121,10 @@ export class ItemsComponent {
       this.members.set(
         members.map((m, idx) => ({
           userId: m.userId,
-          label: m.userId === currentId ? "Tú" : `Miembro ${idx + 1}`,
+          label:
+            m.userId === currentId
+              ? "Tú"
+              : m.fullName ?? `Miembro ${idx + 1}`,
         })),
       );
     });


### PR DESCRIPTION
## Resumen
- Incluye nombre completo de cada miembro en la API de miembros del hogar
- Muestra el nombre del usuario en la interfaz de división de ítems

## Testing
- `npm test` (backend)
- `npm run lint` (backend)
- `npm run build` (backend)
- `npm test` (frontend) *(falla: No binary for Chrome)*
- `npm run lint` (frontend) *(falla: Missing script "lint")*
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689bdfe19ff08326a619509be3b19aad