### PR TITLE
refactor: compute category names map

### DIFF
--- a/Frontend/src/app/features/dashboard/items/items.component.html
+++ b/Frontend/src/app/features/dashboard/items/items.component.html
@@ -91,7 +91,9 @@
           <div>
             <h3 class="item__title">{{ item.name }}</h3>
             <div class="item__meta">
-              {{ getCategoryName(item.categoryId) }} • {{ getStatusLabel(item.status) }}
+              {{ categoryNameMap().get(item.categoryId || '') ?? '' }} • {{
+                getStatusLabel(item.status)
+              }}
             </div>
           </div>
           <div class="item__price">

--- a/Frontend/src/app/features/dashboard/items/items.component.ts
+++ b/Frontend/src/app/features/dashboard/items/items.component.ts
@@ -53,6 +53,14 @@ export class ItemsComponent {
 
   readonly items = signal<Item[]>([]);
   readonly categories = this.categoryService.categories;
+  readonly categoryNameMap = computed(
+    () =>
+      new Map(
+        this.categoryService
+          .categories()
+          .map((c) => [c.id, c.name] as const),
+      ),
+  );
   readonly currencies$ = this.currencyService.getSupported();
 
   private defaultCurrency = "USD";
@@ -179,11 +187,6 @@ export class ItemsComponent {
     this.itemsService.delete(item.id).subscribe(() => {
       this.items.update((list) => list.filter((i) => i.id !== item.id));
     });
-  }
-
-  getCategoryName(id?: string): string {
-    const cat = this.categories().find((c) => c.id === id);
-    return cat ? cat.name : "";
   }
 
   getStatusLabel(status: ItemStatus): string {


### PR DESCRIPTION
## Summary
- derive a category id->name map via `computed`
- use `categoryNameMap` in items template instead of `getCategoryName`

## Testing
- `npm ci`
- `npm run lint` *(fails: Missing script "lint")*
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689becf4395c832687d0350c4f195e8a