### PR TITLE
Ensure immutable category updates

### DIFF
--- a/Frontend/src/app/core/categories/category.service.ts
+++ b/Frontend/src/app/core/categories/category.service.ts
@@ -55,8 +55,10 @@ export class CategoryService {
       .pipe(
         map(({ category }) => category),
         tap((updated) =>
-          this.categoriesSignal.update((list) =>
-            list.map((c) => (c.id === updated.id ? updated : c)),
+          this.categoriesSignal.set(
+            this.categoriesSignal().map((c) =>
+              c.id === updated.id ? updated : c,
+            ),
           ),
         ),
       );
@@ -71,8 +73,8 @@ export class CategoryService {
       .pipe(
         map(({ category }) => category),
         tap((removed) =>
-          this.categoriesSignal.update((list) =>
-            list.filter((c) => c.id !== removed.id),
+          this.categoriesSignal.set(
+            this.categoriesSignal().filter((c) => c.id !== removed.id),
           ),
         ),
       );


### PR DESCRIPTION
## Summary
- Ensure category `update` and `delete` operations replace state with new arrays via `signal.set`

## Testing
- `npm run build`
- `npm run test` *(fails: No binary for Chrome browser)*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689bfa4a8f988326bdfa036605b50d99